### PR TITLE
Fix counter persistence

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -1052,6 +1052,9 @@ namespace SAM.Game
             foreach (ListViewItem item in _AchievementListView.SelectedItems)
             {
                 item.SubItems[4].Text = timerValue.ToString(); // Fifth column (Display Index 4)
+
+                string key = item.SubItems[3].Text;
+                achievementCounters[key] = timerValue; // Store value for refresh
             }
 
             //MessageBox.Show("Selected rows have been successfully updated!", "Completed", MessageBoxButtons.OK, MessageBoxIcon.Information);


### PR DESCRIPTION
## Summary
- store counter values in a dictionary when adding counters so the data persists across refreshes

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc59520c833081309780ab816f6e