### PR TITLE
Enable x64 builds and 64-bit Steam client selection

### DIFF
--- a/SAM.API/NativeWrapper.cs
+++ b/SAM.API/NativeWrapper.cs
@@ -33,7 +33,8 @@ namespace SAM.API
 
         public override string ToString()
         {
-            return $"Steam Interface<{typeof(TNativeFunctions)}> #{this.ObjectAddress.ToInt32():X8}";
+            string format = IntPtr.Size == 8 ? "X16" : "X8";
+            return $"Steam Interface<{typeof(TNativeFunctions)}> #{this.ObjectAddress.ToInt64().ToString(format)}";
         }
 
         public void SetupFunctions(IntPtr objectAddress)
@@ -78,3 +79,4 @@ namespace SAM.API
         }
     }
 }
+

--- a/SAM.API/SAM.API.csproj
+++ b/SAM.API/SAM.API.csproj
@@ -20,12 +20,12 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <Platforms>x86</Platforms>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/SAM.API/Steam.cs
+++ b/SAM.API/Steam.cs
@@ -123,8 +123,9 @@ namespace SAM.API
 
             Native.SetDllDirectory(path + ";" + Path.Combine(path, "bin"));
 
-            path = Path.Combine(path, "steamclient.dll");
-            IntPtr module = Native.LoadLibraryEx(path, IntPtr.Zero, Native.LoadWithAlteredSearchPath);
+            string library = Environment.Is64BitProcess ? "steamclient64.dll" : "steamclient.dll";
+            string libraryPath = Path.Combine(path, library);
+            IntPtr module = Native.LoadLibraryEx(libraryPath, IntPtr.Zero, Native.LoadWithAlteredSearchPath);
             if (module == IntPtr.Zero)
             {
                 return false;

--- a/SAM.Game/SAM.Game.csproj
+++ b/SAM.Game/SAM.Game.csproj
@@ -23,13 +23,13 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <Platforms>x86</Platforms>
+    <Platforms>x64</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>..\bin\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>..\upload\</OutputPath>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>

--- a/SAM.Picker/MyListView.cs
+++ b/SAM.Picker/MyListView.cs
@@ -49,7 +49,7 @@ namespace SAM.Picker
                 case 0x0100: // WM_KEYDOWN
                 {
                     ScrollEventType type;
-                    if (TranslateKeyScrollEvent((Keys)m.WParam.ToInt32(), out type) == true)
+                    if (TranslateKeyScrollEvent((Keys)(int)m.WParam.ToInt64(), out type) == true)
                     {
                         this.OnScroll(new(type, Win32.GetScrollPos(this.Handle, 1 /*SB_VERT*/)));
                     }
@@ -117,3 +117,4 @@ namespace SAM.Picker
         }
     }
 }
+

--- a/SAM.Picker/SAM.Picker.csproj
+++ b/SAM.Picker/SAM.Picker.csproj
@@ -23,13 +23,13 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <Platforms>x86</Platforms>
+    <Platforms>x64</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>..\bin\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>..\upload\</OutputPath>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>

--- a/SAM.sln
+++ b/SAM.sln
@@ -10,24 +10,24 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.Game", "SAM.Game\SAM.Game.csproj", "{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|x86.ActiveCfg = Debug|x86
-		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|x86.Build.0 = Debug|x86
-		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|x86.ActiveCfg = Release|x86
-		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|x86.Build.0 = Release|x86
-		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|x86.ActiveCfg = Debug|x86
-		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|x86.Build.0 = Debug|x86
-		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|x86.ActiveCfg = Release|x86
-		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|x86.Build.0 = Release|x86
-		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|x86.ActiveCfg = Debug|x86
-		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|x86.Build.0 = Debug|x86
-		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x86.ActiveCfg = Release|x86
-		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x86.Build.0 = Release|x86
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|x64 = Debug|x64
+                Release|x64 = Release|x64
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|x64.ActiveCfg = Debug|x64
+                {E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|x64.Build.0 = Debug|x64
+                {E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|x64.ActiveCfg = Release|x64
+                {E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|x64.Build.0 = Release|x64
+                {DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|x64.ActiveCfg = Debug|x64
+                {DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|x64.Build.0 = Debug|x64
+                {DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|x64.ActiveCfg = Release|x64
+                {DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|x64.Build.0 = Release|x64
+                {7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|x64.ActiveCfg = Debug|x64
+                {7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|x64.Build.0 = Debug|x64
+                {7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x64.ActiveCfg = Release|x64
+                {7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x64.Build.0 = Release|x64
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
@@ -35,3 +35,4 @@ Global
 		SolutionGuid = {FB343317-9FA7-49C3-A55C-D95A69E836EC}
 	EndGlobalSection
 EndGlobal
+


### PR DESCRIPTION
## Summary
- switch all projects and the solution to x64 configurations
- load steamclient64.dll when running in 64-bit and use pointer-size safe IntPtr conversions

## Testing
- `dotnet build SAM.sln -c Release -p:Platform=x64` *(fails: Non-string resources require System.Resources.Extensions)*

------
https://chatgpt.com/codex/tasks/task_e_689c24159d6883309824698e48f0094d