### PR TITLE
Fix GetISteamApps delegate signature for SteamClient018

### DIFF
--- a/SAM.API/Wrappers/SteamClient018.cs
+++ b/SAM.API/Wrappers/SteamClient018.cs
@@ -180,7 +180,8 @@ namespace SAM.API.Wrappers
         #endregion
 
         #region GetISteamApps
-        private delegate IntPtr NativeGetISteamApps(int user, int pipe, IntPtr version);
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private delegate IntPtr NativeGetISteamApps(IntPtr self, int user, int pipe, IntPtr version);
 
         private TClass GetISteamApps<TClass>(int user, int pipe, string version)
             where TClass : INativeWrapper, new()
@@ -189,6 +190,7 @@ namespace SAM.API.Wrappers
             {
                 IntPtr address = this.Call<IntPtr, NativeGetISteamApps>(
                     this.Functions.GetISteamApps,
+                    this.ObjectAddress,
                     user,
                     pipe,
                     nativeVersion.Handle);


### PR DESCRIPTION
## Summary
- add ThisCall delegate with self pointer for GetISteamApps
- ensure native call supplies wrapper's object address

## Testing
- `xbuild /p:Configuration=Release /p:Platform=x64 SAM.sln` *(fails: Invalid solution configuration and platform: "Release|x64".)*


------
https://chatgpt.com/codex/tasks/task_e_689c3c0c09608330ad5d7c1b5db38639