### PR TITLE
Add null check for native interface pointer

### DIFF
--- a/SAM.API/NativeWrapper.cs
+++ b/SAM.API/NativeWrapper.cs
@@ -39,6 +39,9 @@ namespace SAM.API
 
         public void SetupFunctions(IntPtr objectAddress)
         {
+            if (objectAddress == IntPtr.Zero)
+                throw new ArgumentNullException(nameof(objectAddress), "Interface pointer is null.");
+
             this.ObjectAddress = objectAddress;
 
             var iface = (NativeClass)Marshal.PtrToStructure(


### PR DESCRIPTION
## Summary
- throw `ArgumentNullException` in `SetupFunctions` when the native interface pointer is null

## Testing
- `dotnet build` *(fails: Non-string resources require GenerateResourceUsePreserializedResources to be set to true)*
- `dotnet build SAM.API/SAM.API.csproj -c Debug -p:Platform=x64`


------
https://chatgpt.com/codex/tasks/task_e_689c48a8c7448330a4b2ec05439f9fd9