### PR TITLE
Improve icon cache loading speed

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -278,13 +278,12 @@ namespace SAM.Picker
                 {
                     if (File.Exists(cacheFile) == true)
                     {
-                        using (var file = File.OpenRead(cacheFile))
-                        {
-                            using var image = Image.FromStream(file);
-                            Bitmap bitmap = new(image);
-                            e.Result = new LogoInfo(info.Id, bitmap);
-                            return;
-                        }
+                        var bytes = File.ReadAllBytes(cacheFile);
+                        using var stream = new MemoryStream(bytes, false);
+                        using var image = Image.FromStream(stream, false, false);
+                        Bitmap bitmap = new(image);
+                        e.Result = new LogoInfo(info.Id, bitmap);
+                        return;
                     }
                 }
                 catch (Exception)


### PR DESCRIPTION
## Summary
- optimize icon cache loading by reading cached PNGs into memory streams and skipping image validation

## Testing
- `dotnet build` *(fails: Non-string resources require the System.Resources.Extensions assembly)*

------
https://chatgpt.com/codex/tasks/task_e_689c61c138a88330a9a346165380926d