### PR TITLE
Dispose achievement icons after adding to list

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -185,6 +185,7 @@ namespace SAM.Game
                 var key = info.Id + "_" + (info.IsAchieved == true ? "achieved" : "locked");
                 info.ImageIndex = this._AchievementImageList.Images.Count;
                 this._AchievementImageList.Images.Add(key, icon);
+                icon.Dispose();
             }
         }
 
@@ -223,6 +224,7 @@ namespace SAM.Game
                 }
 
                 this.AddAchievementIcon(info, bitmap);
+                bitmap = null;
                 this._AchievementListView.Update();
             }
 
@@ -699,8 +701,7 @@ namespace SAM.Game
                             using (var file = File.OpenRead(cachePath))
                             {
                                 using var image = Image.FromStream(file);
-                                Bitmap bitmap = new(image);
-                                this.AddAchievementIcon(info, bitmap);
+                                this.AddAchievementIcon(info, new Bitmap(image));
                                 return;
                             }
                         }


### PR DESCRIPTION
## Summary
- Dispose icon bitmaps once added to `_AchievementImageList`
- Avoid retaining references to disposed bitmaps in callers

## Testing
- `dotnet build` *(fails: System.Resources.Extensions assembly not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c808f4d6c8330a2d4500a3656b3d6