### PR TITLE
Remove UserPaint style from DoubleBufferedListView

### DIFF
--- a/SAM.Game/DoubleBufferedListView.cs
+++ b/SAM.Game/DoubleBufferedListView.cs
@@ -28,12 +28,11 @@ namespace SAM.Game
         {
                 public DoubleBufferedListView()
                 {
-                        // Reduce flicker by enabling additional double buffering
-                        // styles and preventing background erase messages.
+                        // Reduce flicker by enabling double buffering styles
+                        // while relying on default ListView painting behavior.
                         SetStyle(
                             ControlStyles.OptimizedDoubleBuffer |
-                            ControlStyles.AllPaintingInWmPaint |
-                            ControlStyles.UserPaint,
+                            ControlStyles.AllPaintingInWmPaint,
                             true);
                         DoubleBuffered = true;
                         UpdateStyles();


### PR DESCRIPTION
## Summary
- Fix DoubleBufferedListView by dropping `ControlStyles.UserPaint` so default ListView rendering occurs

## Testing
- `dotnet build` *(fails: Non-string resources require System.Resources.Extensions assembly)*

------
https://chatgpt.com/codex/tasks/task_e_689c92cc67a48330b13819c94877e7eb