### PR TITLE
Use HttpClient for game and icon downloads

### DIFF
--- a/SAM.Picker/SAM.Picker.csproj
+++ b/SAM.Picker/SAM.Picker.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="MyListView.cs">


### PR DESCRIPTION
## Summary
- replace WebClient usage with a shared HttpClient for game list and icon retrieval
- add async helper leveraging `GetByteArrayAsync` and dispose client on form close
- add missing System.Net.Http assembly reference to fix build errors

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ca20b1b808330b5e7e43c114655a3