### PR TITLE
Add localized game names and language selector

### DIFF
--- a/SAM.Picker/GamePicker.Designer.cs
+++ b/SAM.Picker/GamePicker.Designer.cs
@@ -213,7 +213,7 @@
             this._LanguageLabel.Name = "_LanguageLabel";
             this._LanguageLabel.Size = new System.Drawing.Size(140, 39);
             this._LanguageLabel.Text = "Language";
-            this._LanguageLabel.Visible = false;
+            this._LanguageLabel.Visible = true;
             // 
             // _LanguageComboBox
             // 
@@ -251,7 +251,7 @@
             "vietnamese"});
             this._LanguageComboBox.Name = "_LanguageComboBox";
             this._LanguageComboBox.Size = new System.Drawing.Size(160, 45);
-            this._LanguageComboBox.Visible = false;
+            this._LanguageComboBox.Visible = true;
             // 
             // _PickerStatusStrip
             // 

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -108,7 +108,7 @@ namespace SAM.Picker
                 return;
             }
 
-            game.Name = this._SteamClient.SteamApps001.GetAppData(game.Id, "name");
+            game.Name = this.GetLocalizedName(game.Id);
 
             this.AddGameToLogoQueue(game);
             this.DownloadNextLogo();
@@ -481,6 +481,64 @@ namespace SAM.Picker
             return this._SteamClient.SteamApps008.IsSubscribedApp(id);
         }
 
+        private string GetLocalizedName(uint id)
+        {
+            string currentLanguage;
+
+            try
+            {
+                if (this._LanguageComboBox.Text.Length == 0)
+                {
+                    currentLanguage = this._SteamClient.SteamApps008.GetCurrentGameLanguage();
+                    if (string.IsNullOrEmpty(currentLanguage))
+                    {
+                        currentLanguage = "english";
+                    }
+                    this._LanguageComboBox.Text = currentLanguage;
+                }
+                else
+                {
+                    currentLanguage = this._LanguageComboBox.Text;
+                }
+            }
+            catch (Exception)
+            {
+                currentLanguage = "english";
+            }
+
+            string name = null;
+
+            try
+            {
+                name = this._SteamClient.SteamApps001.GetAppData(id, _($"name_{currentLanguage}"));
+                if (string.IsNullOrEmpty(name) == true && currentLanguage != "english")
+                {
+                    name = this._SteamClient.SteamApps001.GetAppData(id, "name_english");
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            if (string.IsNullOrEmpty(name) == true)
+            {
+                try
+                {
+                    name = this._SteamClient.SteamApps001.GetAppData(id, "name");
+                }
+                catch (Exception)
+                {
+                }
+            }
+
+            if (string.IsNullOrEmpty(name) == true)
+            {
+                name = id.ToString(CultureInfo.InvariantCulture);
+            }
+
+            return name;
+        }
+
         private void AddGame(uint id, string type)
         {
             if (this._Games.ContainsKey(id) == true)
@@ -494,7 +552,7 @@ namespace SAM.Picker
             }
 
             GameInfo info = new(id, type);
-            info.Name = this._SteamClient.SteamApps001.GetAppData(info.Id, "name");
+            info.Name = this.GetLocalizedName(info.Id);
             this._Games.Add(id, info);
         }
 


### PR DESCRIPTION
## Summary
- add `GetLocalizedName` helper using Steam's language data with fallbacks
- use localized names when adding games and refreshing app data
- expose language selector in picker UI for manual overrides

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689d2ea532708330989106ce52a75ff9