### PR TITLE
Add localized game names and language selector

### DIFF
--- a/SAM.Picker/GamePicker.Designer.cs
+++ b/SAM.Picker/GamePicker.Designer.cs
@@ -213,7 +213,7 @@
             this._LanguageLabel.Name = "_LanguageLabel";
             this._LanguageLabel.Size = new System.Drawing.Size(140, 39);
             this._LanguageLabel.Text = "Language";
-            this._LanguageLabel.Visible = false;
+            this._LanguageLabel.Visible = true;
             // 
             // _LanguageComboBox
             // 
@@ -251,7 +251,7 @@
             "vietnamese"});
             this._LanguageComboBox.Name = "_LanguageComboBox";
             this._LanguageComboBox.Size = new System.Drawing.Size(160, 45);
-            this._LanguageComboBox.Visible = false;
+            this._LanguageComboBox.Visible = true;
             // 
             // _PickerStatusStrip
             // 


### PR DESCRIPTION
## Summary
- add `GetLocalizedName` helper using Steam's language data with fallbacks
- use localized names when adding games and refreshing app data
- expose language selector in picker UI for manual overrides
- refresh picker data immediately when language selection changes

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d2ea532708330989106ce52a75ff9