### PR TITLE
Validate executable paths before launching

### DIFF
--- a/SAM.Game/Program.cs
+++ b/SAM.Game/Program.cs
@@ -21,7 +21,9 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Windows.Forms;
 
 namespace SAM.Game
@@ -35,7 +37,29 @@ namespace SAM.Game
 
             if (args.Length == 0)
             {
-                Process.Start("SAM.Picker.exe");
+                string pickerExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SAM.Picker.exe");
+                if (File.Exists(pickerExe) == false)
+                {
+                    MessageBox.Show(
+                        "SAM.Picker.exe is missing.",
+                        "Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                    return;
+                }
+
+                try
+                {
+                    Process.Start(pickerExe);
+                }
+                catch (Win32Exception)
+                {
+                    MessageBox.Show(
+                        "Failed to start SAM.Picker.exe.",
+                        "Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
                 return;
             }
 

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -532,9 +532,21 @@ namespace SAM.Picker
                 return;
             }
 
+            string gameExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SAM.Game.exe");
+            if (File.Exists(gameExe) == false)
+            {
+                MessageBox.Show(
+                    this,
+                    "SAM.Game.exe is missing.",
+                    "Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return;
+            }
+
             try
             {
-                Process.Start("SAM.Game.exe", info.Id.ToString(CultureInfo.InvariantCulture));
+                Process.Start(gameExe, info.Id.ToString(CultureInfo.InvariantCulture));
             }
             catch (Win32Exception)
             {


### PR DESCRIPTION
## Summary
- Ensure SAM.Game.exe and SAM.Picker.exe are invoked using full paths based on the app's directory
- Display user-friendly errors when target executables are missing or fail to start

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689d4856712c8330a65fac73c2b8ba62