### PR TITLE
Use HttpClient for game list download with default certificate validation

### DIFF
--- a/SAM.Picker/GameList.cs
+++ b/SAM.Picker/GameList.cs
@@ -1,17 +1,16 @@
 using System;
 using System.IO;
-using System.Net;
-using System.Net.Security;
+using System.Net.Http;
 
 namespace SAM.Picker
 {
     internal static class GameList
     {
-        public static byte[] Load(string baseDirectory, Func<Uri, byte[]> downloader, out bool usedLocal)
+        public static byte[] Load(string baseDirectory, HttpClient httpClient, out bool usedLocal)
         {
-            if (downloader == null)
+            if (httpClient == null)
             {
-                throw new ArgumentNullException(nameof(downloader));
+                throw new ArgumentNullException(nameof(httpClient));
             }
 
             string localPath = Path.Combine(baseDirectory, "games.xml");
@@ -32,18 +31,10 @@ namespace SAM.Picker
 
             try
             {
-                RemoteCertificateValidationCallback previousCallback = ServicePointManager.ServerCertificateValidationCallback;
-                ServicePointManager.ServerCertificateValidationCallback = (_, _, _, _) => true;
-                try
-                {
-                    bytes = downloader(new Uri("https://gib.me/sam/games.xml"));
-                }
-                finally
-                {
-                    ServicePointManager.ServerCertificateValidationCallback = previousCallback;
-                }
+                bytes = httpClient.GetByteArrayAsync(new Uri("https://gib.me/sam/games.xml"))
+                    .GetAwaiter().GetResult();
             }
-            catch
+            catch (HttpRequestException)
             {
             }
 

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -126,7 +126,7 @@ namespace SAM.Picker
             bool usedLocal;
             byte[] bytes = GameList.Load(
                 AppDomain.CurrentDomain.BaseDirectory,
-                uri => this.DownloadDataAsync(uri).GetAwaiter().GetResult(),
+                this._HttpClient,
                 out usedLocal);
 
             //Silent load from local file if network fails


### PR DESCRIPTION
## Summary
- remove global ServerCertificateValidationCallback override
- fetch game list using HttpClient's default certificate validation
- adjust tests to use failing handler

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d4e4c3d5483308d09288c9e9c1e8e