### PR TITLE
Harden network downloads with size limits and validation

### DIFF
--- a/SAM.Picker.Tests/GameListTests.cs
+++ b/SAM.Picker.Tests/GameListTests.cs
@@ -32,6 +32,38 @@ public class GameListTests
             GameList.Load(temp, client, out _));
     }
 
+    [Fact]
+    public void RejectsOversizedNetworkResponse()
+    {
+        string temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(temp);
+        string local = Path.Combine(temp, "games.xml");
+        File.WriteAllText(local, "<games><game type='normal'>1</game></games>");
+
+        using HttpClient client = new(new OversizedHandler());
+        byte[] bytes = GameList.Load(temp, client, out bool usedLocal);
+
+        Assert.True(usedLocal);
+        Assert.NotNull(bytes);
+    }
+
+    [Fact]
+    public void RejectsCorruptedNetworkFile()
+    {
+        string temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(temp);
+        string local = Path.Combine(temp, "games.xml");
+        // use real bundled file to match expected checksum
+        string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        File.Copy(Path.Combine(repoRoot, "SAM.Picker", "games.xml"), local);
+
+        using HttpClient client = new(new CorruptedHandler());
+        byte[] bytes = GameList.Load(temp, client, out bool usedLocal);
+
+        Assert.True(usedLocal);
+        Assert.NotNull(bytes);
+    }
+
     private sealed class FailingHandler : HttpMessageHandler
     {
         protected override System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
@@ -39,6 +71,40 @@ public class GameListTests
             CancellationToken cancellationToken)
         {
             throw new HttpRequestException("fail");
+        }
+    }
+
+    private sealed class OversizedHandler : HttpMessageHandler
+    {
+        protected override System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            byte[] data = new byte[GameList.MaxDownloadBytes + 1];
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(data),
+            };
+            response.Content.Headers.ContentLength = data.Length;
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/xml");
+            return System.Threading.Tasks.Task.FromResult(response);
+        }
+    }
+
+    private sealed class CorruptedHandler : HttpMessageHandler
+    {
+        protected override System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            byte[] data = new byte[] { 1, 2, 3, 4 };
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(data),
+            };
+            response.Content.Headers.ContentLength = data.Length;
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/xml");
+            return System.Threading.Tasks.Task.FromResult(response);
         }
     }
 }


### PR DESCRIPTION
## Summary
- limit downloaded response sizes for game list and icon images
- verify games.xml integrity via SHA256
- validate image headers and dimensions before caching
- add tests covering oversized and corrupted game list downloads

## Testing
- `dotnet test`
- `dotnet build` *(fails: Non-string resources require System.Resources.Extensions)*

------
https://chatgpt.com/codex/tasks/task_e_689d523b771c833091fd158ec45c6196