### PR TITLE
Sanitize achievement cache path IDs

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -173,7 +173,17 @@ namespace SAM.Game
             {
                 return null;
             }
-            var fileName = info.Id + "_" + (info.IsAchieved == true ? "achieved" : "locked") + ".png";
+
+            var id = info.Id;
+            var invalid = Path.GetInvalidFileNameChars();
+            if (id.IndexOfAny(invalid) >= 0 ||
+                id.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+                id.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+            {
+                id = Uri.EscapeDataString(id);
+            }
+
+            var fileName = id + "_" + (info.IsAchieved == true ? "achieved" : "locked") + ".png";
             return Path.Combine(this._IconCacheDirectory, fileName);
         }
 


### PR DESCRIPTION
## Summary
- sanitize achievement cache path IDs before saving icons

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d6ff94d0c83308ac85e8e4542b383