### PR TITLE
Cache owned games in GamePicker

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -639,7 +639,14 @@ namespace SAM.Picker
                     writer.WriteEndElement();
                 }
 
-                File.Move(tempPath, path, true);
+                if (File.Exists(path) == true)
+                {
+                    File.Replace(tempPath, path, null);
+                }
+                else
+                {
+                    File.Move(tempPath, path);
+                }
             }
             catch (Exception ex)
             {

--- a/SAM.Picker/usergames.xml
+++ b/SAM.Picker/usergames.xml
@@ -1,0 +1,4 @@
+<games>
+    <game id="123"/>
+    <game id="456"/>
+</games>


### PR DESCRIPTION
## Summary
- load cached owned games from usergames.xml before network list
- skip duplicates and persist current games to cache
- add sample usergames.xml file

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d7e17dcc883308aae0b6fe379e7f6