### PR TITLE
Use length-aware native string conversions

### DIFF
--- a/SAM.API/GlobalSuppressions.cs
+++ b/SAM.API/GlobalSuppressions.cs
@@ -183,7 +183,6 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "pointer", Scope = "member", Target = "SAM.API.NativeWrapper`1.#GetDelegate`1(System.IntPtr)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "pointer", Scope = "member", Target = "SAM.API.NativeWrapper`1.#GetFunction`1(System.IntPtr)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1725:ParameterNamesShouldMatchBaseDeclaration", MessageId = "0#", Scope = "member", Target = "SAM.API.Callback`1.#Run(System.IntPtr)")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "SAM.API.NativeStrings.#PointerToString(System.Byte*)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "SAM.API.NativeStrings.#PointerToString(System.Byte*,System.Int32)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Scope = "type", Target = "SAM.API.Interfaces.ISteamApps001")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Scope = "type", Target = "SAM.API.Interfaces.ISteamApps003")]

--- a/SAM.API/NativeStrings.cs
+++ b/SAM.API/NativeStrings.cs
@@ -71,39 +71,6 @@ namespace SAM.API
             return new StringHandle(p, true);
         }
 
-        public static unsafe string PointerToString(sbyte* bytes)
-        {
-            if (bytes == null)
-            {
-                return null;
-            }
-
-            int running = 0;
-
-            var b = bytes;
-            if (*b == 0)
-            {
-                return string.Empty;
-            }
-
-            while ((*b++) != 0)
-            {
-                running++;
-            }
-
-            return new string(bytes, 0, running, Encoding.UTF8);
-        }
-
-        public static unsafe string PointerToString(byte* bytes)
-        {
-            return PointerToString((sbyte*)bytes);
-        }
-
-        public static unsafe string PointerToString(IntPtr nativeData)
-        {
-            return PointerToString((sbyte*)nativeData.ToPointer());
-        }
-
         public static unsafe string PointerToString(sbyte* bytes, int length)
         {
             if (bytes == null)
@@ -111,17 +78,22 @@ namespace SAM.API
                 return null;
             }
 
-            int running = 0;
-
-            var b = bytes;
-            if (length == 0 || *b == 0)
+            if (length <= 0)
             {
                 return string.Empty;
             }
 
-            while ((*b++) != 0 &&
-                   running < length)
+            int running = 0;
+            var b = bytes;
+
+            if (*b == 0)
             {
+                return string.Empty;
+            }
+
+            while (running < length && *b != 0)
+            {
+                b++;
                 running++;
             }
 

--- a/SAM.API/SAM.API.csproj
+++ b/SAM.API/SAM.API.csproj
@@ -28,4 +28,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="SAM.Picker.Tests" />
+  </ItemGroup>
 </Project>

--- a/SAM.API/Wrappers/SteamApps008.cs
+++ b/SAM.API/Wrappers/SteamApps008.cs
@@ -48,7 +48,11 @@ namespace SAM.API.Wrappers
             var languagePointer = this.Call<IntPtr, NativeGetCurrentGameLanguage>(
                 this.Functions.GetCurrentGameLanguage,
                 this.ObjectAddress);
-            return NativeStrings.PointerToString(languagePointer);
+            if (languagePointer == IntPtr.Zero)
+            {
+                return null;
+            }
+            return NativeStrings.PointerToString(languagePointer, 1024);
         }
         #endregion
     }

--- a/SAM.API/Wrappers/SteamUserStats013.cs
+++ b/SAM.API/Wrappers/SteamUserStats013.cs
@@ -201,7 +201,11 @@ namespace SAM.API.Wrappers
                     this.ObjectAddress,
                     nativeName.Handle,
                     nativeKey.Handle);
-                return NativeStrings.PointerToString(result);
+                if (result == IntPtr.Zero)
+                {
+                    return null;
+                }
+                return NativeStrings.PointerToString(result, 1024);
             }
         }
         #endregion

--- a/SAM.API/Wrappers/SteamUtils005.cs
+++ b/SAM.API/Wrappers/SteamUtils005.cs
@@ -45,7 +45,11 @@ namespace SAM.API.Wrappers
         public string GetIPCountry()
         {
             var result = this.Call<IntPtr, NativeGetIPCountry>(this.Functions.GetIPCountry, this.ObjectAddress);
-            return NativeStrings.PointerToString(result);
+            if (result == IntPtr.Zero)
+            {
+                return null;
+            }
+            return NativeStrings.PointerToString(result, 16);
         }
         #endregion
 

--- a/SAM.Picker.Tests/NativeStringsTests.cs
+++ b/SAM.Picker.Tests/NativeStringsTests.cs
@@ -1,0 +1,46 @@
+using System;
+using Xunit;
+using SAM.API;
+
+namespace SAM.Picker.Tests
+{
+    public class NativeStringsTests
+    {
+        [Fact]
+        public unsafe void PointerToString_DoesNotReadPastProvidedLength()
+        {
+            var buffer = stackalloc sbyte[6];
+            buffer[0] = (sbyte)'a';
+            buffer[1] = (sbyte)'b';
+            buffer[2] = (sbyte)'c';
+            buffer[3] = (sbyte)'d';
+            buffer[4] = (sbyte)'e';
+            buffer[5] = 0;
+
+            var result = NativeStrings.PointerToString(buffer, 3);
+            Assert.Equal("abc", result);
+        }
+
+        [Fact]
+        public unsafe void PointerToString_NoTerminatorWithinLength()
+        {
+            var buffer = stackalloc sbyte[5];
+            buffer[0] = (sbyte)'a';
+            buffer[1] = (sbyte)'b';
+            buffer[2] = (sbyte)'c';
+            buffer[3] = (sbyte)'d';
+            buffer[4] = (sbyte)'e';
+
+            var result = NativeStrings.PointerToString(buffer, 5);
+            Assert.Equal("abcde", result);
+        }
+
+        [Fact]
+        public unsafe void PointerToString_NullPointerReturnsNull()
+        {
+            sbyte* buffer = null;
+            var result = NativeStrings.PointerToString(buffer, 5);
+            Assert.Null(result);
+        }
+    }
+}

--- a/SAM.Picker.Tests/SAM.Picker.Tests.csproj
+++ b/SAM.Picker.Tests/SAM.Picker.Tests.csproj
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\\SAM.Picker\\GameList.cs" Link="GameList.cs" />
+    <ProjectReference Include="..\\SAM.API\\SAM.API.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
## Summary
- replace unbounded native string helper with length-checked version
- guard native string reads in Steam wrappers with explicit bounds and null handling
- add tests for bounded UTF-8 pointer conversion

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689d8994f4088330a28a095e68449777