### PR TITLE
chore: add net8 target and align test platform

### DIFF
--- a/SAM.API/SAM.API.csproj
+++ b/SAM.API/SAM.API.csproj
@@ -18,7 +18,7 @@
     <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>

--- a/SAM.Picker.Tests/SAM.Picker.Tests.csproj
+++ b/SAM.Picker.Tests/SAM.Picker.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\\SAM.Picker\\GameList.cs" Link="GameList.cs" />


### PR DESCRIPTION
## Summary
- multi-target SAM.API for .NET 4.8 and 8.0
- mark test project as x64 to match SAM.API platform

## Testing
- `dotnet build SAM.Picker.Tests/SAM.Picker.Tests.csproj -p:Platform=x64`
- `dotnet build SAM.Picker/SAM.Picker.csproj -p:Platform=x64` *(fails: Non-string resources require System.Resources.Extensions)*
- `dotnet build SAM.Game/SAM.Game.csproj -p:Platform=x64` *(fails: Non-string resources require System.Resources.Extensions)*

------
https://chatgpt.com/codex/tasks/task_e_689d92806fbc8330a01da9d957119204