### PR TITLE
Use pattern matching for ToolStripButton checks

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -1082,7 +1082,7 @@ namespace SAM.Game
 
         private void OnDisplayUncheckedOnly(object sender, EventArgs e)
         {
-            if ((sender as ToolStripButton).Checked == true)
+            if (sender is ToolStripButton button && button.Checked)
             {
                 this._DisplayLockedOnlyButton.Checked = false;
             }
@@ -1092,7 +1092,7 @@ namespace SAM.Game
 
         private void OnDisplayCheckedOnly(object sender, EventArgs e)
         {
-            if ((sender as ToolStripButton).Checked == true)
+            if (sender is ToolStripButton button && button.Checked)
             {
                 this._DisplayUnlockedOnlyButton.Checked = false;
             }


### PR DESCRIPTION
## Summary
- replace sender cast with pattern matching in display filter handlers

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d9ff8e6fc8330bc3c00049b47b136