### PR TITLE
Target .NET Framework in Picker tests

### DIFF
--- a/SAM.Picker.Tests/SAM.Picker.Tests.csproj
+++ b/SAM.Picker.Tests/SAM.Picker.Tests.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>x64</Platforms>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\\SAM.Picker\\GameList.cs" Link="GameList.cs" />
     <ProjectReference Include="..\\SAM.API\\SAM.API.csproj" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
## Summary
- test project now targets both .NET Framework 4.8 and .NET 8
- enable C# 9 features and add System.Net.Http reference for framework compatibility

## Testing
- `dotnet test SAM.Picker.Tests/SAM.Picker.Tests.csproj -f net8.0 -p:Platform=x64`
- `dotnet test SAM.Picker.Tests/SAM.Picker.Tests.csproj -f net48 -p:Platform=x64` *(fails: Cannot open assembly '... testhost.net48.exe')*


------
https://chatgpt.com/codex/tasks/task_e_689da80dc440833087a012676be9a3de