### PR TITLE
Initialize StatDefinition strings

### DIFF
--- a/SAM.Game/Stats/StatDefinition.cs
+++ b/SAM.Game/Stats/StatDefinition.cs
@@ -24,8 +24,8 @@ namespace SAM.Game.Stats
 {
     internal abstract class StatDefinition
     {
-        public string Id;
-        public string DisplayName;
+        public string Id = string.Empty;
+        public string DisplayName = string.Empty;
         public int Permission;
     }
 }


### PR DESCRIPTION
## Summary
- avoid nullability warnings by initializing `StatDefinition` string fields

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc14f2c70833089118f0cd7ff58c7