### PR TITLE
Initialize nullable fields

### DIFF
--- a/SAM.Game/KeyValue.cs
+++ b/SAM.Game/KeyValue.cs
@@ -32,7 +32,7 @@ namespace SAM.Game
         private static readonly KeyValue _Invalid = new();
         public string Name = "<root>";
         public KeyValueType Type = KeyValueType.None;
-        public object Value;
+        public object? Value;
         public bool Valid;
 
         public List<KeyValue> Children = null;
@@ -85,24 +85,24 @@ namespace SAM.Game
                 case KeyValueType.String:
                 case KeyValueType.WideString:
                 {
-                    return int.TryParse((string)this.Value, out int value) == false
+                    return int.TryParse((string)this.Value!, out int value) == false
                         ? defaultValue
                         : value;
                 }
 
                 case KeyValueType.Int32:
                 {
-                    return (int)this.Value;
+                    return (int)this.Value!;
                 }
 
                 case KeyValueType.Float32:
                 {
-                    return (int)((float)this.Value);
+                    return (int)((float)this.Value!);
                 }
 
                 case KeyValueType.UInt64:
                 {
-                    return (int)((ulong)this.Value & 0xFFFFFFFF);
+                    return (int)((ulong)this.Value! & 0xFFFFFFFF);
                 }
             }
 
@@ -121,24 +121,24 @@ namespace SAM.Game
                 case KeyValueType.String:
                 case KeyValueType.WideString:
                 {
-                    return float.TryParse((string)this.Value, out float value) == false
+                    return float.TryParse((string)this.Value!, out float value) == false
                         ? defaultValue
                         : value;
                 }
 
                 case KeyValueType.Int32:
                 {
-                    return (int)this.Value;
+                    return (int)this.Value!;
                 }
 
                 case KeyValueType.Float32:
                 {
-                    return (float)this.Value;
+                    return (float)this.Value!;
                 }
 
                 case KeyValueType.UInt64:
                 {
-                    return (ulong)this.Value & 0xFFFFFFFF;
+                    return (ulong)this.Value! & 0xFFFFFFFF;
                 }
             }
 
@@ -157,24 +157,24 @@ namespace SAM.Game
                 case KeyValueType.String:
                 case KeyValueType.WideString:
                 {
-                    return int.TryParse((string)this.Value, out int value) == false
+                    return int.TryParse((string)this.Value!, out int value) == false
                         ? defaultValue
                         : value != 0;
                 }
 
                 case KeyValueType.Int32:
                 {
-                    return ((int)this.Value) != 0;
+                    return ((int)this.Value!) != 0;
                 }
 
                 case KeyValueType.Float32:
                 {
-                    return ((int)((float)this.Value)) != 0;
+                    return ((int)((float)this.Value!)) != 0;
                 }
 
                 case KeyValueType.UInt64:
                 {
-                    return ((ulong)this.Value) != 0;
+                    return ((ulong)this.Value!) != 0;
                 }
             }
 

--- a/SAM.Game/Stats/AchievementInfo.cs
+++ b/SAM.Game/Stats/AchievementInfo.cs
@@ -35,7 +35,7 @@ namespace SAM.Game.Stats
         public string? IconLocked = string.Empty;
         public string Name = string.Empty;
         public string Description = string.Empty;
-        public ListViewItem Item;
+        public ListViewItem Item = null!;
 
         #region public int ImageIndex;
         public int ImageIndex

--- a/SAM.Game/Stats/StatInfo.cs
+++ b/SAM.Game/Stats/StatInfo.cs
@@ -25,8 +25,8 @@ namespace SAM.Game.Stats
     internal abstract class StatInfo
     {
         public abstract bool IsModified { get; }
-        public string Id { get; set; }
-        public string DisplayName { get; set; }
+        public string Id { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
         public abstract object Value { get; set; }
         public bool IsIncrementOnly { get; set; }
         public int Permission { get; set; }


### PR DESCRIPTION
## Summary
- initialize ListViewItem field in AchievementInfo
- default StatInfo identifiers to empty strings
- allow nullable values in KeyValue and add null-forgiving casts

## Testing
- `dotnet build` *(fails: System.Resources.Extensions missing)*
- `dotnet test` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_689dd091d7388330b3f35e639748e9de