### PR TITLE
chore: fix nullable reference warnings

### DIFF
--- a/SAM.Game/KeyValue.cs
+++ b/SAM.Game/KeyValue.cs
@@ -35,7 +35,7 @@ namespace SAM.Game
         public object? Value;
         public bool Valid;
 
-        public List<KeyValue> Children = null;
+        public List<KeyValue>? Children = null;
 
         public KeyValue this[string key]
         {
@@ -196,7 +196,7 @@ namespace SAM.Game
             return $"{this.Name} = {this.Value}";
         }
 
-        public static KeyValue LoadAsBinary(string path)
+        public static KeyValue? LoadAsBinary(string path)
         {
             if (File.Exists(path) == false)
             {

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -193,7 +193,7 @@ namespace SAM.Game
             return Path.Combine(this._IconCacheDirectory, fileName);
         }
 
-        private void AddAchievementIcon(Stats.AchievementInfo info, Image icon)
+        private void AddAchievementIcon(Stats.AchievementInfo info, Image? icon)
         {
             if (icon == null)
             {
@@ -222,7 +222,7 @@ namespace SAM.Game
             var info = this._IconQueue[0];
             this._IconQueue.RemoveAt(0);
 
-            Bitmap bitmap = null;
+            Bitmap? bitmap = null;
             try
             {
                 bitmap = await this.DownloadIconAsync(info);


### PR DESCRIPTION
## Summary
- allow null achievement icons and handle nullable bitmaps during download
- permit missing child lists and allow KeyValue to return null when loading

## Testing
- `dotnet test` *(fails: Testhost process for net48 could not start; net8 tests pass)*
- `dotnet build` *(fails: Non-string resources require System.Resources.Extensions assembly)*

------
https://chatgpt.com/codex/tasks/task_e_689dd2ace1308330b12a4a7a4be5c8bb