### PR TITLE
Use AddDllDirectory for Steam library loading

### DIFF
--- a/SAM.Picker.Tests/SteamTests.cs
+++ b/SAM.Picker.Tests/SteamTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using SAM.API;
+using Xunit;
+
+namespace SAM.Picker.Tests
+{
+    public class SteamTests
+    {
+        private static class Native
+        {
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+            public static extern int GetDllDirectory(int nBufferLength, StringBuilder lpBuffer);
+        }
+
+        [Fact]
+        public void LoadDoesNotChangeDllDirectory()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            const int capacity = 260;
+            var before = new StringBuilder(capacity);
+            Native.GetDllDirectory(capacity, before);
+
+            Steam.Load();
+            Steam.Unload();
+
+            var after = new StringBuilder(capacity);
+            Native.GetDllDirectory(capacity, after);
+
+            Assert.Equal(before.ToString(), after.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid global SetDllDirectory calls when loading steamclient
- load steamclient.dll with LOAD_LIBRARY_SEARCH flags and restore DLL directory handles
- ensure loading leaves process DLL search path unchanged

## Testing
- `dotnet test --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_689de016e24c8330af203a86fbdd850f