### PR TITLE
Guard StreamHelpers against truncated reads

### DIFF
--- a/SAM.Game.Tests/SAM.Game.Tests.csproj
+++ b/SAM.Game.Tests/SAM.Game.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>x64</Platforms>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\\SAM.Game\\StreamHelpers.cs" Link="StreamHelpers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+</Project>

--- a/SAM.Game.Tests/StreamHelpersTests.cs
+++ b/SAM.Game.Tests/StreamHelpersTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Text;
+using SAM.Game;
+using Xunit;
+
+public class StreamHelpersTests
+{
+    [Fact]
+    public void ReadValueS32_ThrowsOnTruncatedStream()
+    {
+        using var stream = new MemoryStream(new byte[3]);
+        Assert.Throws<EndOfStreamException>(() => stream.ReadValueS32());
+    }
+
+    [Fact]
+    public void ReadValueU32_ThrowsOnTruncatedStream()
+    {
+        using var stream = new MemoryStream(new byte[3]);
+        Assert.Throws<EndOfStreamException>(() => stream.ReadValueU32());
+    }
+
+    [Fact]
+    public void ReadValueU64_ThrowsOnTruncatedStream()
+    {
+        using var stream = new MemoryStream(new byte[7]);
+        Assert.Throws<EndOfStreamException>(() => stream.ReadValueU64());
+    }
+
+    [Fact]
+    public void ReadValueF32_ThrowsOnTruncatedStream()
+    {
+        using var stream = new MemoryStream(new byte[3]);
+        Assert.Throws<EndOfStreamException>(() => stream.ReadValueF32());
+    }
+
+    [Fact]
+    public void ReadStringAscii_ThrowsOnTruncatedStream()
+    {
+        using var stream = new MemoryStream(Encoding.ASCII.GetBytes("abc"));
+        Assert.Throws<EndOfStreamException>(() => stream.ReadStringAscii());
+    }
+}

--- a/SAM.Game/StreamHelpers.cs
+++ b/SAM.Game/StreamHelpers.cs
@@ -39,7 +39,10 @@ namespace SAM.Game
         {
             var data = new byte[4];
             int read = stream.Read(data, 0, 4);
-            Debug.Assert(read == 4);
+            if (read != 4)
+            {
+                throw new EndOfStreamException();
+            }
             return BitConverter.ToInt32(data, 0);
         }
 
@@ -47,7 +50,10 @@ namespace SAM.Game
         {
             var data = new byte[4];
             int read = stream.Read(data, 0, 4);
-            Debug.Assert(read == 4);
+            if (read != 4)
+            {
+                throw new EndOfStreamException();
+            }
             return BitConverter.ToUInt32(data, 0);
         }
 
@@ -55,7 +61,10 @@ namespace SAM.Game
         {
             var data = new byte[8];
             int read = stream.Read(data, 0, 8);
-            Debug.Assert(read == 8);
+            if (read != 8)
+            {
+                throw new EndOfStreamException();
+            }
             return BitConverter.ToUInt64(data, 0);
         }
 
@@ -63,7 +72,10 @@ namespace SAM.Game
         {
             var data = new byte[4];
             int read = stream.Read(data, 0, 4);
-            Debug.Assert(read == 4);
+            if (read != 4)
+            {
+                throw new EndOfStreamException();
+            }
             return BitConverter.ToSingle(data, 0);
         }
 
@@ -84,7 +96,10 @@ namespace SAM.Game
                 }
 
                 int read = stream.Read(data, i, characterSize);
-                Debug.Assert(read == characterSize);
+                if (read != characterSize)
+                {
+                    throw new EndOfStreamException();
+                }
 
                 if (encoding.GetString(data, i, characterSize) == characterEnd)
                 {

--- a/SAM.sln
+++ b/SAM.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.Game", "SAM.Game\SAM.Ga
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAM.Picker.Tests", "SAM.Picker.Tests\SAM.Picker.Tests.csproj", "{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAM.Game.Tests", "SAM.Game.Tests\SAM.Game.Tests.csproj", "{4169025E-B068-4FBE-9D60-863C1C5CF0FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -29,13 +31,17 @@ Global
 		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|x64.Build.0 = Debug|x64
 		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x64.ActiveCfg = Release|x64
 		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x64.Build.0 = Release|x64
-		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Debug|x64.ActiveCfg = Debug|x64
-		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Debug|x64.Build.0 = Debug|x64
-		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Release|x64.ActiveCfg = Release|x64
-		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+                {22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Debug|x64.ActiveCfg = Debug|x64
+                {22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Debug|x64.Build.0 = Debug|x64
+                {22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Release|x64.ActiveCfg = Release|x64
+                {22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Release|x64.Build.0 = Release|x64
+                {4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Debug|x64.ActiveCfg = Debug|x64
+                {4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Debug|x64.Build.0 = Debug|x64
+                {4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Release|x64.ActiveCfg = Release|x64
+                {4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Release|x64.Build.0 = Release|x64
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB343317-9FA7-49C3-A55C-D95A69E836EC}


### PR DESCRIPTION
## Summary
- check Stream.Read results in StreamHelpers and throw `EndOfStreamException` when truncated
- add tests verifying truncated streams trigger exceptions

## Testing
- `dotnet test --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689dea68458883309936026ecc7a0442