### PR TITLE
Pin Valve certificate subject when loading steamclient

### DIFF
--- a/SAM.API/Steam.cs
+++ b/SAM.API/Steam.cs
@@ -182,6 +182,14 @@ namespace SAM.API
                     {
                         return false;
                     }
+
+                    // Pin the certificate identity to Valve's known subject
+                    const string ValveSubject = "CN=Valve Corp., O=Valve Corp., L=Bellevue, S=Washington, C=US";
+                    var subject = certificate.Subject;
+                    if (string.Equals(subject, ValveSubject, StringComparison.OrdinalIgnoreCase) == false)
+                    {
+                        return false;
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
## Summary
- ensure `Steam.Load` validates steamclient's certificate subject matches Valve

## Testing
- `dotnet test` *(fails: cannot open assembly '/usr/lib/dotnet/sdk/8.0.118/Extensions/../TestHostNetFramework/testhost.net48.exe')*
- `dotnet test` *(passes: SAM.Game.Tests (net8.0), SAM.Picker.Tests (net8.0))*

------
https://chatgpt.com/codex/tasks/task_e_689df3dee48483308889792c0f6c19d3