### PR TITLE
Enforce maximum string length in stream helpers

### DIFF
--- a/SAM.Game.Tests/StreamHelpersTests.cs
+++ b/SAM.Game.Tests/StreamHelpersTests.cs
@@ -40,4 +40,20 @@ public class StreamHelpersTests
         using var stream = new MemoryStream(Encoding.ASCII.GetBytes("abc"));
         Assert.Throws<EndOfStreamException>(() => stream.ReadStringAscii());
     }
+
+    [Fact]
+    public void ReadStringAscii_ThrowsOnExceededLimit()
+    {
+        var text = new string('a', 4097);
+        using var stream = new MemoryStream(Encoding.ASCII.GetBytes(text + '\0'));
+        Assert.Throws<InvalidDataException>(() => stream.ReadStringAscii());
+    }
+
+    [Fact]
+    public void ReadStringUnicode_ThrowsOnExceededLimit()
+    {
+        var text = new string('a', 4097);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(text + '\0'));
+        Assert.Throws<InvalidDataException>(() => stream.ReadStringUnicode());
+    }
 }

--- a/SAM.Game/StreamHelpers.cs
+++ b/SAM.Game/StreamHelpers.cs
@@ -79,7 +79,7 @@ namespace SAM.Game
             return BitConverter.ToSingle(data, 0);
         }
 
-        internal static string ReadStringInternalDynamic(this Stream stream, Encoding encoding, char end)
+        internal static string ReadStringInternalDynamic(this Stream stream, Encoding encoding, char end, int maxLength)
         {
             int characterSize = encoding.GetByteCount("e");
             Debug.Assert(characterSize == 1 || characterSize == 2 || characterSize == 4);
@@ -87,6 +87,7 @@ namespace SAM.Game
 
             int i = 0;
             var data = new byte[128 * characterSize];
+            int length = 0;
 
             while (true)
             {
@@ -107,6 +108,11 @@ namespace SAM.Game
                 }
 
                 i += characterSize;
+                length++;
+                if (length > maxLength)
+                {
+                    throw new InvalidDataException("String exceeded maximum allowed length");
+                }
             }
 
             if (i == 0)
@@ -119,12 +125,14 @@ namespace SAM.Game
 
         public static string ReadStringAscii(this Stream stream)
         {
-            return stream.ReadStringInternalDynamic(Encoding.ASCII, '\0');
+            const int maxLength = 4096;
+            return stream.ReadStringInternalDynamic(Encoding.ASCII, '\0', maxLength);
         }
 
         public static string ReadStringUnicode(this Stream stream)
         {
-            return stream.ReadStringInternalDynamic(Encoding.UTF8, '\0');
+            const int maxLength = 4096;
+            return stream.ReadStringInternalDynamic(Encoding.UTF8, '\0', maxLength);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add maximum length enforcement to dynamic string reader
- limit ASCII and Unicode string reads to 4096 characters
- cover oversized strings with new unit tests

## Testing
- `dotnet test` *(fails: Could not find 'mono' host)*
- `dotnet test` *(pass: SAM.Game.Tests.dll (net8.0), SAM.Picker.Tests.dll (net8.0))*

------
https://chatgpt.com/codex/tasks/task_e_689dfc5ad52c83309490b03bdaa95081