### PR TITLE
Validate logo URLs before download

### DIFF
--- a/SAM.Picker.Tests/LogoUrlValidatorTests.cs
+++ b/SAM.Picker.Tests/LogoUrlValidatorTests.cs
@@ -1,0 +1,26 @@
+using SAM.Picker;
+using Xunit;
+
+public class LogoUrlValidatorTests
+{
+    [Theory]
+    [InlineData("https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/123/foo.png", true)]
+    [InlineData("https://cdn.steamstatic.com/steamcommunity/public/images/apps/123/foo.jpg", true)]
+    [InlineData("http://cdn.steamstatic.com/steamcommunity/public/images/apps/123/foo.jpg", false)]
+    [InlineData("https://example.com/image.png", false)]
+    [InlineData("not a url", false)]
+    public void ValidatesUrls(string url, bool expected)
+    {
+        var result = ImageUrlValidator.TryCreateUri(url, out var uri);
+        Assert.Equal(expected, result);
+        if (expected)
+        {
+            Assert.NotNull(uri);
+        }
+        else
+        {
+            Assert.Null(uri);
+        }
+    }
+}
+

--- a/SAM.Picker.Tests/SAM.Picker.Tests.csproj
+++ b/SAM.Picker.Tests/SAM.Picker.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\\SAM.Picker\\GameList.cs" Link="GameList.cs" />
+    <Compile Include="..\\SAM.Picker\\ImageUrlValidator.cs" Link="ImageUrlValidator.cs" />
     <ProjectReference Include="..\\SAM.API\\SAM.API.csproj" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -341,6 +341,12 @@ namespace SAM.Picker
 
             this._LogosAttempted.Add(info.ImageUrl);
 
+            if (ImageUrlValidator.TryCreateUri(info.ImageUrl, out var uri) == false)
+            {
+                e.Result = new LogoInfo(info.Id, null);
+                return;
+            }
+
             string cacheFile = null;
             if (this._UseIconCache == true)
             {
@@ -371,7 +377,7 @@ namespace SAM.Picker
 
             try
             {
-                var (data, contentType) = this.DownloadDataAsync(new Uri(info.ImageUrl)).GetAwaiter().GetResult();
+                var (data, contentType) = this.DownloadDataAsync(uri).GetAwaiter().GetResult();
                 if (contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == false)
                 {
                     throw new InvalidDataException("Invalid content type");

--- a/SAM.Picker/ImageUrlValidator.cs
+++ b/SAM.Picker/ImageUrlValidator.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace SAM.Picker
+{
+    internal static class ImageUrlValidator
+    {
+        private static readonly HashSet<string> AllowedHosts = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "shared.cloudflare.steamstatic.com",
+            "cdn.steamstatic.com",
+        };
+
+        public static bool TryCreateUri(string url, out Uri uri)
+        {
+            uri = null;
+
+            if (string.IsNullOrEmpty(url) == true)
+            {
+                return false;
+            }
+
+            if (Uri.TryCreate(url, UriKind.Absolute, out var candidate) == false)
+            {
+                return false;
+            }
+
+            if (candidate.Scheme != Uri.UriSchemeHttps)
+            {
+                return false;
+            }
+
+            if (AllowedHosts.Contains(candidate.Host) == false)
+            {
+                return false;
+            }
+
+            uri = candidate;
+            return true;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure game logo downloads only use HTTPS URLs on trusted Steam domains
- add URL validator and tests for logo URL sanitization

## Testing
- `dotnet test` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_689dfc49c8788330a01db950508ee0bb