### PR TITLE
harden XML parsing

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -178,7 +178,13 @@ namespace SAM.Picker
             List<KeyValuePair<uint, string>> pairs = new();
             using (MemoryStream stream = new(bytes, false))
             {
-                XPathDocument document = new(stream);
+                XmlReaderSettings settings = new()
+                {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null,
+                };
+                using var reader = XmlReader.Create(stream, settings);
+                var document = new XPathDocument(reader);
                 var navigator = document.CreateNavigator();
                 var nodes = navigator.Select("/games/game");
                 while (nodes.MoveNext() == true)
@@ -629,7 +635,13 @@ namespace SAM.Picker
                 }
 
                 using var stream = File.OpenRead(path);
-                XPathDocument document = new(stream);
+                XmlReaderSettings settings = new()
+                {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null,
+                };
+                using var reader = XmlReader.Create(stream, settings);
+                var document = new XPathDocument(reader);
                 var navigator = document.CreateNavigator();
                 var nodes = navigator.Select("/games/game");
                 while (nodes.MoveNext() == true)


### PR DESCRIPTION
## Summary
- use XmlReader with DTD disabled and no resolver when loading downloaded game list
- apply same hardened XmlReader settings for cached owned games

## Testing
- `dotnet test` *(fails: Testhost process for net48 not found; System.Drawing.Common unsupported on non-Windows)*

------
https://chatgpt.com/codex/tasks/task_e_689e9b002a408330924fe862ba0c1324