### PR TITLE
Use ApplicationConfiguration.Initialize

### DIFF
--- a/SAM.Game/Program.cs
+++ b/SAM.Game/Program.cs
@@ -131,8 +131,7 @@ namespace SAM.Game
                     return;
                 }
 
-                Application.EnableVisualStyles();
-                Application.SetCompatibleTextRenderingDefault(false);
+                ApplicationConfiguration.Initialize();
                 Application.Run(new Manager(appId, client));
             }
         }

--- a/SAM.Picker/Program.cs
+++ b/SAM.Picker/Program.cs
@@ -77,8 +77,7 @@ namespace SAM.Picker
                     return;
                 }
 
-                Application.EnableVisualStyles();
-                Application.SetCompatibleTextRenderingDefault(false);
+                ApplicationConfiguration.Initialize();
                 Application.Run(new GamePicker(client));
             }
         }


### PR DESCRIPTION
## Summary
- initialize WinForms via `ApplicationConfiguration.Initialize()` in Game and Picker programs

## Testing
- `dotnet test` *(fails: Project SAM.API is not compatible with net48 /.NETFramework,Version=v4.8)*

------
https://chatgpt.com/codex/tasks/task_e_689eaa7bbb508330b49ffb1f45b74298