### PR TITLE
chore: remove obsolete System.Net.Http references

### DIFF
--- a/SAM.Game/SAM.Game.csproj
+++ b/SAM.Game/SAM.Game.csproj
@@ -39,9 +39,6 @@
     <Content Include="SAM.Game.ico" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Update="DoubleBufferedListView.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/SAM.Picker/SAM.Picker.csproj
+++ b/SAM.Picker/SAM.Picker.csproj
@@ -35,9 +35,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Update="MyListView.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
## Summary
- remove redundant System.Net.Http references from SAM.Game and SAM.Picker project files

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec1b53668833096c302a33c5788e6