### PR TITLE
Remove obsolete serialization constructor

### DIFF
--- a/SAM.Game/Stats/StatIsProtectedException.cs
+++ b/SAM.Game/Stats/StatIsProtectedException.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Runtime.Serialization;
 
 namespace SAM.Game.Stats
 {
@@ -39,11 +38,6 @@ namespace SAM.Game.Stats
 
         public StatIsProtectedException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        protected StatIsProtectedException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
## Summary
- drop unused SerializationInfo constructor from `StatIsProtectedException`

## Testing
- `dotnet build SAM.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec7ce0be083308ff6d6f160e4baea