### PR TITLE
Fix nullability warning in AsString

### DIFF
--- a/SAM.Game/KeyValue.cs
+++ b/SAM.Game/KeyValue.cs
@@ -70,7 +70,7 @@ namespace SAM.Game
                 return defaultValue;
             }
 
-            return this.Value.ToString();
+            return this.Value!.ToString()!;
         }
 
         public int AsInteger(int defaultValue)


### PR DESCRIPTION
## Summary
- use null-forgiving operator in `KeyValue.AsString`

## Testing
- `dotnet build SAM.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test SAM.sln`


------
https://chatgpt.com/codex/tasks/task_e_689eca35b13c8330af7f10d8f50a3533