### PR TITLE
Use nullable out parameter in ImageUrlValidator.TryCreateUri

### DIFF
--- a/SAM.Picker/ImageUrlValidator.cs
+++ b/SAM.Picker/ImageUrlValidator.cs
@@ -11,7 +11,7 @@ namespace SAM.Picker
             "cdn.steamstatic.com",
         };
 
-        public static bool TryCreateUri(string url, out Uri uri)
+        public static bool TryCreateUri(string url, out Uri? uri)
         {
             uri = null;
 


### PR DESCRIPTION
## Summary
- allow `ImageUrlValidator.TryCreateUri` to output nullable URIs

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ecca2dc0c83309cd7713e6dd32fae