### PR TITLE
Enable nullable context for ImageUrlValidator

### DIFF
--- a/SAM.Picker/ImageUrlValidator.cs
+++ b/SAM.Picker/ImageUrlValidator.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 


### PR DESCRIPTION
## Summary
- enable nullable reference types in ImageUrlValidator

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ed876c8988330b7a9642181ced953