### PR TITLE
Enable nullable context in GameList

### DIFF
--- a/SAM.Picker/GameList.cs
+++ b/SAM.Picker/GameList.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.IO;
 using System.Net.Http;


### PR DESCRIPTION
## Summary
- enable nullable annotations for GameList to allow proper use of nullable reference types

## Testing
- `dotnet build -p:EnableWindowsTargeting=true`
- `dotnet test -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_689eda5436788330b65238507bb0de6c