### PR TITLE
Remove DPI awareness setting from manifest

### DIFF
--- a/SAM.Picker/app.manifest
+++ b/SAM.Picker/app.manifest
@@ -24,9 +24,4 @@
     </application>
   </compatibility>
 
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-    </windowsSettings>
-  </application>
 </assembly>


### PR DESCRIPTION
## Summary
- remove `dpiAware` entry from Windows manifest to rely on `ApplicationHighDpiMode`

## Testing
- `dotnet build SAM.Picker/SAM.Picker.csproj -c Release` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*


------
https://chatgpt.com/codex/tasks/task_e_689eda5dd66083309549d23d8e8c1ddc