### PR TITLE
Add WinUI 3 picker and shared core library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,20 @@
 5. **Countdown to Commit Achievements**: Users can set a countdown timer for committing achievements. Multiple achievements and their respective countdown durations can be configured, and the "Enable Timer" button will execute the countdown.
 6. **Some UI tweaks**: Sorting by listview columns by [r33yl](https://github.com/r33yl), prevent Steam client show activicaty as idle (only when SAM.Game in foreground and turned-on).  
 7. **Icon cache**: Implemented icon cache for SAM.Picker and SAM.Game. Cache folder is under program folder named "appcache".  
-8. **Game list cache**: Implemented game list cache for SAM.Picker. Cache folder is under binaries folder named "appcache".  
-9. **Error handling**: Many error handlings and reduce possible vulnerabilities.  
+8. **Game list cache**: Implemented game list cache for SAM.Picker. Cache folder is under binaries folder named "appcache".
+9. **Error handling**: Many error handlings and reduce possible vulnerabilities.
+
+---
+
+## Modern Picker
+
+`SAM.Picker.Modern` is a new WinUI 3 front‑end that shares game loading and icon caching logic with the classic picker. It presents the game list using data bindings and asynchronous logo downloads.
+
+### Build and Run
+
+1. Install the [Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/) and .NET 8 with the Windows workload.
+2. Open `SAM.sln` in Visual Studio and build the `SAM.Picker.Modern` project.
+3. Run the project; selecting a game will launch `SAM.Game.exe` as usual.
 
 ---
 

--- a/SAM.Picker.Core/GameList.cs
+++ b/SAM.Picker.Core/GameList.cs
@@ -6,12 +6,12 @@ using System.Net.Http;
 using System.Xml;
 using System.Xml.Linq;
 
-namespace SAM.Picker
+namespace SAM.Picker.Core
 {
-    internal static class GameList
+    public static class GameList
     {
         // Maximum allowed size for the games.xml download.
-        internal const int MaxDownloadBytes = 2 * 1024 * 1024; // 2 MB
+        public const int MaxDownloadBytes = 2 * 1024 * 1024; // 2 MB
 
         public static byte[] Load(string baseDirectory, HttpClient httpClient, out bool usedLocal)
         {

--- a/SAM.Picker.Core/IconCache.cs
+++ b/SAM.Picker.Core/IconCache.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SAM.Picker.Core
+{
+    public class IconCache
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _directory;
+        private readonly bool _useCache;
+
+        private const int MaxLogoBytes = 512 * 1024; // 512 KB
+        private const int MaxLogoDimension = 1024; // px
+
+        public IconCache(HttpClient httpClient, string directory)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _directory = directory ?? throw new ArgumentNullException(nameof(directory));
+            try
+            {
+                Directory.CreateDirectory(_directory);
+                _useCache = true;
+            }
+            catch
+            {
+                _useCache = false;
+            }
+        }
+
+        public async Task<byte[]?> GetOrDownloadAsync(uint id, Uri uri)
+        {
+            string? cacheFile = _useCache ? Path.Combine(_directory, id + ".png") : null;
+
+            if (cacheFile != null && File.Exists(cacheFile))
+            {
+                try
+                {
+                    var bytes = await File.ReadAllBytesAsync(cacheFile);
+                    if (bytes.Length <= MaxLogoBytes && Validate(bytes))
+                    {
+                        return bytes;
+                    }
+                }
+                catch
+                {
+                    try { if (cacheFile != null) File.Delete(cacheFile); } catch { }
+                }
+            }
+
+            var (data, contentType) = await DownloadDataAsync(uri);
+            if (!contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (Validate(data) == false)
+            {
+                return null;
+            }
+
+            if (cacheFile != null)
+            {
+                try { await File.WriteAllBytesAsync(cacheFile, data); } catch { }
+            }
+
+            return data;
+        }
+
+        private bool Validate(byte[] data)
+        {
+            try
+            {
+                using var stream = new MemoryStream(data, false);
+                using var image = Image.FromStream(stream, false, true);
+                return image.Width <= MaxLogoDimension && image.Height <= MaxLogoDimension;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private async Task<(byte[] Data, string ContentType)> DownloadDataAsync(Uri uri)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+
+            var contentLength = response.Content.Headers.ContentLength;
+            if (contentLength == null || contentLength.Value > MaxLogoBytes)
+            {
+                throw new HttpRequestException("Response too large or missing length");
+            }
+
+            var contentType = response.Content.Headers.ContentType?.MediaType ?? string.Empty;
+
+            using var stream = await response.Content.ReadAsStreamAsync();
+            var data = await ReadWithLimitAsync(stream, MaxLogoBytes);
+            return (data, contentType);
+        }
+
+        private static async Task<byte[]> ReadWithLimitAsync(Stream stream, int maxBytes)
+        {
+            using MemoryStream memory = new();
+            byte[] buffer = new byte[81920];
+            int read;
+            int total = 0;
+            while ((read = await stream.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            {
+                total += read;
+                if (total > maxBytes)
+                {
+                    throw new HttpRequestException("Response exceeded maximum allowed size");
+                }
+                await memory.WriteAsync(buffer.AsMemory(0, read));
+            }
+            return memory.ToArray();
+        }
+    }
+}

--- a/SAM.Picker.Core/ImageUrlValidator.cs
+++ b/SAM.Picker.Core/ImageUrlValidator.cs
@@ -3,9 +3,9 @@
 using System;
 using System.Collections.Generic;
 
-namespace SAM.Picker
+namespace SAM.Picker.Core
 {
-    internal static class ImageUrlValidator
+    public static class ImageUrlValidator
     {
         private static readonly HashSet<string> AllowedHosts = new(StringComparer.OrdinalIgnoreCase)
         {

--- a/SAM.Picker.Core/SAM.Picker.Core.csproj
+++ b/SAM.Picker.Core/SAM.Picker.Core.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/SAM.Picker.Modern/App.xaml
+++ b/SAM.Picker.Modern/App.xaml
@@ -1,0 +1,5 @@
+<Application
+    x:Class="SAM.Picker.Modern.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</Application>

--- a/SAM.Picker.Modern/App.xaml.cs
+++ b/SAM.Picker.Modern/App.xaml.cs
@@ -1,0 +1,20 @@
+using Microsoft.UI.Xaml;
+
+namespace SAM.Picker.Modern
+{
+    public partial class App : Application
+    {
+        private Window? _window;
+
+        public App()
+        {
+            this.InitializeComponent();
+        }
+
+        protected override void OnLaunched(LaunchActivatedEventArgs args)
+        {
+            _window = new MainWindow();
+            _window.Activate();
+        }
+    }
+}

--- a/SAM.Picker.Modern/GameViewModel.cs
+++ b/SAM.Picker.Modern/GameViewModel.cs
@@ -1,0 +1,25 @@
+using Microsoft.UI.Xaml.Media.Imaging;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace SAM.Picker.Modern
+{
+    public class GameViewModel : INotifyPropertyChanged
+    {
+        public uint Id { get; }
+        private string _name;
+        public string Name { get => _name; set { _name = value; OnPropertyChanged(); } }
+        private BitmapImage? _logo;
+        public BitmapImage? Logo { get => _logo; set { _logo = value; OnPropertyChanged(); } }
+
+        public GameViewModel(uint id, string name)
+        {
+            Id = id;
+            _name = name;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/SAM.Picker.Modern/MainViewModel.cs
+++ b/SAM.Picker.Modern/MainViewModel.cs
@@ -1,0 +1,116 @@
+using SAM.Picker.Core;
+using API = SAM.API;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.XPath;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage.Streams;
+using System.Diagnostics;
+using System.Runtime.InteropServices.WindowsRuntime;
+
+namespace SAM.Picker.Modern
+{
+    public class MainViewModel
+    {
+        private readonly API.Client _client;
+        private readonly HttpClient _httpClient;
+        private readonly IconCache _iconCache;
+
+        public ObservableCollection<GameViewModel> Games { get; } = new();
+        public ObservableCollection<GameViewModel> FilteredGames { get; } = new();
+
+        public MainViewModel()
+        {
+            _client = new API.Client();
+            _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+            _iconCache = new IconCache(_httpClient, Path.Combine(AppContext.BaseDirectory, "appcache"));
+        }
+
+        public async Task LoadAsync()
+        {
+            await Task.Run(() =>
+            {
+                bool usedLocal;
+                var bytes = GameList.Load(AppContext.BaseDirectory, _httpClient, out usedLocal);
+                using var stream = new MemoryStream(bytes, false);
+                var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
+                using var reader = XmlReader.Create(stream, settings);
+                var document = new XPathDocument(reader);
+                var navigator = document.CreateNavigator();
+                var nodes = navigator.Select("/games/game");
+                while (nodes.MoveNext())
+                {
+                    string type = nodes.Current.GetAttribute("type", "");
+                    if (string.IsNullOrEmpty(type)) { type = "normal"; }
+                    uint id = (uint)nodes.Current.ValueAsLong;
+                    if (_client.SteamApps008.IsSubscribedApp(id))
+                    {
+                        var name = _client.SteamApps001.GetAppData(id, "name");
+                        var game = new GameViewModel(id, name);
+                        Games.Add(game);
+                    }
+                }
+            });
+
+            foreach (var game in Games)
+            {
+                AddFiltered(game);
+                _ = LoadLogoAsync(game);
+            }
+        }
+
+        private void AddFiltered(GameViewModel game)
+        {
+            FilteredGames.Add(game);
+        }
+
+        public void Filter(string text)
+        {
+            FilteredGames.Clear();
+            foreach (var game in Games.Where(g => string.IsNullOrEmpty(text) || g.Name.Contains(text, StringComparison.OrdinalIgnoreCase)))
+            {
+                FilteredGames.Add(game);
+            }
+        }
+
+        private async Task LoadLogoAsync(GameViewModel game)
+        {
+            var url = _client.SteamApps001.GetAppData(game.Id, "logo");
+            if (string.IsNullOrEmpty(url)) return;
+            if (!ImageUrlValidator.TryCreateUri(url, out var uri) ) return;
+            try
+            {
+                var data = await _iconCache.GetOrDownloadAsync(game.Id, uri);
+                if (data == null) return;
+                using InMemoryRandomAccessStream mem = new();
+                await mem.WriteAsync(data.AsBuffer());
+                mem.Seek(0);
+                BitmapImage bmp = new();
+                await bmp.SetSourceAsync(mem);
+                game.Logo = bmp;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+        }
+
+        public void Launch(GameViewModel game)
+        {
+            try
+            {
+                var exe = Path.Combine(AppContext.BaseDirectory, "SAM.Game.exe");
+                Process.Start(new ProcessStartInfo(exe, game.Id.ToString()) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/SAM.Picker.Modern/MainWindow.xaml
+++ b/SAM.Picker.Modern/MainWindow.xaml
@@ -1,0 +1,21 @@
+<Window
+    x:Class="SAM.Picker.Modern.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:SAM.Picker.Modern"
+    Title="SAM Picker Modern">
+    <StackPanel>
+        <TextBox x:Name="SearchBox" PlaceholderText="Search" Margin="8" TextChanged="OnSearchTextChanged"/>
+        <ListView x:Name="GameList" ItemsSource="{x:Bind ViewModel.FilteredGames, Mode=OneWay}" SelectionMode="Single">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="local:GameViewModel">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Image Width="32" Height="32" Source="{x:Bind Logo, Mode=OneWay}"/>
+                        <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center"/>
+                        <Button Content="Launch" Click="OnLaunchClicked"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </StackPanel>
+</Window>

--- a/SAM.Picker.Modern/MainWindow.xaml.cs
+++ b/SAM.Picker.Modern/MainWindow.xaml.cs
@@ -1,0 +1,30 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace SAM.Picker.Modern
+{
+    public sealed partial class MainWindow : Window
+    {
+        public MainViewModel ViewModel { get; } = new();
+
+        public MainWindow()
+        {
+            this.InitializeComponent();
+            this.DataContext = ViewModel;
+            this.Loaded += async (_, __) => await ViewModel.LoadAsync();
+        }
+
+        private void OnSearchTextChanged(object sender, TextChangedEventArgs e)
+        {
+            ViewModel.Filter(SearchBox.Text);
+        }
+
+        private void OnLaunchClicked(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button button && button.DataContext is GameViewModel game)
+            {
+                ViewModel.Launch(game);
+            }
+        }
+    }
+}

--- a/SAM.Picker.Modern/SAM.Picker.Modern.csproj
+++ b/SAM.Picker.Modern/SAM.Picker.Modern.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWinUI>true</UseWinUI>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.3" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SAM.API\SAM.API.csproj" />
+    <ProjectReference Include="..\SAM.Picker.Core\SAM.Picker.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/SAM.Picker.Modern/SAM.Picker.Modern.csproj
+++ b/SAM.Picker.Modern/SAM.Picker.Modern.csproj
@@ -5,6 +5,9 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers></RuntimeIdentifiers>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.3" />

--- a/SAM.Picker.Tests/GameListTests.cs
+++ b/SAM.Picker.Tests/GameListTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Text;
-using SAM.Picker;
+using SAM.Picker.Core;
 using Xunit;
 
 public class GameListTests

--- a/SAM.Picker.Tests/LogoUrlValidatorTests.cs
+++ b/SAM.Picker.Tests/LogoUrlValidatorTests.cs
@@ -1,4 +1,4 @@
-using SAM.Picker;
+using SAM.Picker.Core;
 using Xunit;
 
 public class LogoUrlValidatorTests

--- a/SAM.Picker.Tests/SAM.Picker.Tests.csproj
+++ b/SAM.Picker.Tests/SAM.Picker.Tests.csproj
@@ -8,9 +8,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\\SAM.Picker\\GameList.cs" Link="GameList.cs" />
-    <Compile Include="..\\SAM.Picker\\ImageUrlValidator.cs" Link="ImageUrlValidator.cs" />
     <ProjectReference Include="..\\SAM.API\\SAM.API.csproj" />
+    <ProjectReference Include="..\\SAM.Picker.Core\\SAM.Picker.Core.csproj" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>

--- a/SAM.Picker/SAM.Picker.csproj
+++ b/SAM.Picker/SAM.Picker.csproj
@@ -60,5 +60,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SAM.API\SAM.API.csproj" />
+    <ProjectReference Include="..\SAM.Picker.Core\SAM.Picker.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/SAM.sln
+++ b/SAM.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAM.Picker.Tests", "SAM.Pic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAM.Game.Tests", "SAM.Game.Tests\SAM.Game.Tests.csproj", "{4169025E-B068-4FBE-9D60-863C1C5CF0FA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.Picker.Core", "SAM.Picker.Core\SAM.Picker.Core.csproj", "{13E372E3-8066-438F-A6E1-AB576A69E971}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.Picker.Modern", "SAM.Picker.Modern\SAM.Picker.Modern.csproj", "{A71DF081-6757-450F-8990-66155476C01C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -37,9 +41,17 @@ Global
 		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Release|x64.Build.0 = Release|x64
 		{4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Debug|x64.ActiveCfg = Debug|x64
 		{4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Debug|x64.Build.0 = Debug|x64
-		{4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Release|x64.ActiveCfg = Release|x64
-		{4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
+                {4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Release|x64.ActiveCfg = Release|x64
+                {4169025E-B068-4FBE-9D60-863C1C5CF0FA}.Release|x64.Build.0 = Release|x64
+                {13E372E3-8066-438F-A6E1-AB576A69E971}.Debug|x64.ActiveCfg = Debug|x64
+                {13E372E3-8066-438F-A6E1-AB576A69E971}.Debug|x64.Build.0 = Debug|x64
+                {13E372E3-8066-438F-A6E1-AB576A69E971}.Release|x64.ActiveCfg = Release|x64
+                {13E372E3-8066-438F-A6E1-AB576A69E971}.Release|x64.Build.0 = Release|x64
+                {A71DF081-6757-450F-8990-66155476C01C}.Debug|x64.ActiveCfg = Debug|x64
+                {A71DF081-6757-450F-8990-66155476C01C}.Debug|x64.Build.0 = Debug|x64
+                {A71DF081-6757-450F-8990-66155476C01C}.Release|x64.ActiveCfg = Release|x64
+                {A71DF081-6757-450F-8990-66155476C01C}.Release|x64.Build.0 = Release|x64
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add WinUI 3 `SAM.Picker.Modern` project using async bindings
- extract game list and icon cache logic to `SAM.Picker.Core`
- hook up core library to existing picker and solution

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2412160c8330ab261ae87c88bca6