### PR TITLE
Handle missing Content-Length when downloading logos

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -129,9 +129,13 @@ namespace SAM.Picker
             response.EnsureSuccessStatusCode();
 
             var contentLength = response.Content.Headers.ContentLength;
-            if (contentLength == null || contentLength.Value > MaxLogoBytes)
+            if (contentLength == null)
             {
-                throw new HttpRequestException("Response too large or missing length");
+                Debug.WriteLine(_($"Missing Content-Length header for {uri}"));
+            }
+            else if (contentLength.Value > MaxLogoBytes)
+            {
+                throw new HttpRequestException("Response too large");
             }
 
             var contentType = response.Content.Headers.ContentType?.MediaType ?? string.Empty;


### PR DESCRIPTION
## Summary
- allow logo downloads when Content-Length header is missing
- warn when the header is absent while still enforcing the size limit

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689f2b338ca08330a5be7196d729388b