### PR TITLE
Allow Akamai hosted images for logo validation

### DIFF
--- a/SAM.Picker.Tests/LogoUrlValidatorTests.cs
+++ b/SAM.Picker.Tests/LogoUrlValidatorTests.cs
@@ -5,6 +5,7 @@ public class LogoUrlValidatorTests
 {
     [Theory]
     [InlineData("https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/123/foo.png", true)]
+    [InlineData("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/123/foo.png", true)]
     [InlineData("https://cdn.steamstatic.com/steamcommunity/public/images/apps/123/foo.jpg", true)]
     [InlineData("http://cdn.steamstatic.com/steamcommunity/public/images/apps/123/foo.jpg", false)]
     [InlineData("https://example.com/image.png", false)]

--- a/SAM.Picker/ImageUrlValidator.cs
+++ b/SAM.Picker/ImageUrlValidator.cs
@@ -10,6 +10,7 @@ namespace SAM.Picker
         private static readonly HashSet<string> AllowedHosts = new(StringComparer.OrdinalIgnoreCase)
         {
             "shared.cloudflare.steamstatic.com",
+            "shared.akamai.steamstatic.com",
             "cdn.steamstatic.com",
             "shared.steamstatic.com",
         };


### PR DESCRIPTION
## Summary
- permit shared.akamai.steamstatic.com as a valid image host
- add regression test verifying Akamai URLs are accepted

## Testing
- `dotnet test SAM.Picker.Tests -p:Platform=x64`


------
https://chatgpt.com/codex/tasks/task_e_689fd5ba76b48330a79fbe2953ac9625