### PR TITLE
Resize game logos

### DIFF
--- a/SAM.Picker.Tests/LogoResizeTests.cs
+++ b/SAM.Picker.Tests/LogoResizeTests.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Drawing;
+using SAM.Picker;
+using Xunit;
+
+public class LogoResizeTests
+{
+    [Fact]
+    public void OversizedLogoIsResizedToExpectedSize()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var source = new Bitmap(400, 400);
+        using var resized = source.ResizeToFit(new Size(184, 69));
+
+        Assert.Equal(184, resized.Width);
+        Assert.Equal(69, resized.Height);
+    }
+}

--- a/SAM.Picker.Tests/SAM.Picker.Tests.csproj
+++ b/SAM.Picker.Tests/SAM.Picker.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\\SAM.Picker\\GameList.cs" Link="GameList.cs" />
     <Compile Include="..\\SAM.Picker\\ImageUrlValidator.cs" Link="ImageUrlValidator.cs" />
     <Compile Include="..\\SAM.Picker\\GameImageUrlResolver.cs" Link="GameImageUrlResolver.cs" />
+    <Compile Include="..\\SAM.Picker\\BitmapExtensions.cs" Link="BitmapExtensions.cs" />
     <ProjectReference Include="..\\SAM.API\\SAM.API.csproj" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/SAM.Picker/BitmapExtensions.cs
+++ b/SAM.Picker/BitmapExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace SAM.Picker
+{
+    internal static class BitmapExtensions
+    {
+        public static Bitmap ResizeToFit(this Image image, Size target)
+        {
+            var scale = Math.Min((float)target.Width / image.Width, (float)target.Height / image.Height);
+            var width = (int)Math.Round(image.Width * scale);
+            var height = (int)Math.Round(image.Height * scale);
+
+            Bitmap bitmap = new(target.Width, target.Height);
+            using var g = Graphics.FromImage(bitmap);
+            g.Clear(Color.Transparent);
+            g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+            g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+            g.DrawImage(image, (target.Width - width) / 2, (target.Height - height) / 2, width, height);
+            return bitmap;
+        }
+
+        public static byte[] ToPngBytes(this Bitmap bitmap)
+        {
+            using var ms = new MemoryStream();
+            bitmap.Save(ms, ImageFormat.Png);
+            return ms.ToArray();
+        }
+    }
+}

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -662,7 +662,7 @@ namespace SAM.Picker
                                     validateImageData: true);
                                 if (image.Width <= MaxLogoDimension && image.Height <= MaxLogoDimension)
                                 {
-                                    Bitmap bitmap = new(image);
+                                    Bitmap bitmap = image.ResizeToFit(this._LogoImageList.ImageSize);
                                     e.Result = new LogoInfo(info.Id, bitmap);
                                     return;
                                 }
@@ -716,7 +716,7 @@ namespace SAM.Picker
                                     throw new InvalidDataException("Image dimensions too large");
                                 }
 
-                                Bitmap bitmap = new(image);
+                                Bitmap bitmap = image.ResizeToFit(this._LogoImageList.ImageSize);
                                 e.Result = new LogoInfo(info.Id, bitmap);
                                 info.ImageUrl = url;
 
@@ -724,7 +724,8 @@ namespace SAM.Picker
                                 {
                                     try
                                     {
-                                        File.WriteAllBytes(cacheFile, data);
+                                        var cacheData = bitmap.ToPngBytes();
+                                        File.WriteAllBytes(cacheFile, cacheData);
                                     }
                                     catch (Exception)
                                     {


### PR DESCRIPTION
## Summary
- resize logo images to the ImageList size and cache the scaled PNG
- add bitmap helper for resizing with aspect ratio
- test that oversized logos shrink to 184x69

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689fe94dfa388330b76396c0a767665a