### PR TITLE
Apply SetWindowTheme for Explorer dark mode

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -94,6 +94,7 @@ namespace SAM.Game
         private const int TPM_LEFTBUTTON = 0x0000;
         private const int TPM_RIGHTBUTTON = 0x0002;
         private const int TPM_RETURNCMD = 0x0100;
+        private const int LVM_GETHEADER = 0x101F;
 
         private const int DWMWA_SYSTEMBACKDROP_TYPE = 38;
         private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
@@ -1633,10 +1634,16 @@ namespace SAM.Game
                 : "Explorer";
 
             SetWindowTheme(this._AchievementListView.Handle, theme, null);
+            IntPtr header = SendMessage(this._AchievementListView.Handle, LVM_GETHEADER, IntPtr.Zero, IntPtr.Zero);
+            if (header != IntPtr.Zero)
+            {
+                SetWindowTheme(header, theme, null);
+            }
             SetWindowTheme(this._MainTabControl.Handle, theme, null);
             SetWindowTheme(this._MainToolStrip.Handle, theme, null);
             SetWindowTheme(this._AchievementsToolStrip.Handle, theme, null);
             SetWindowTheme(this._StatisticsDataGridView.Handle, theme, null);
+            SetWindowTheme(this._EnableStatsEditingCheckBox.Handle, theme, null);
 
             if (this._MatchingStringTextBox.Control != null)
             {
@@ -1648,9 +1655,9 @@ namespace SAM.Game
                 SetWindowTheme(this._AddTimerTextBox.Control.Handle, theme, null);
             }
 
-            if (this._LanguageComboBox.Control != null)
+            if (this._LanguageComboBox.ComboBox != null)
             {
-                SetWindowTheme(this._LanguageComboBox.Control.Handle, theme, null);
+                SetWindowTheme(this._LanguageComboBox.ComboBox.Handle, theme, null);
             }
         }
 

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -150,6 +150,9 @@ namespace SAM.Game
         [DllImport("user32.dll")]
         private static extern bool ReleaseCapture();
 
+        [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
+        private static extern int SetWindowTheme(IntPtr hwnd, string? pszSubAppName, string? pszSubIdList);
+
         protected override CreateParams CreateParams
         {
             get
@@ -1493,6 +1496,7 @@ namespace SAM.Game
             base.OnHandleCreated(e);
             this.TryApplyMica();
             this.ApplyRoundedCorners();
+            this.ApplyControlThemes();
         }
 
         protected override void OnSizeChanged(EventArgs e)
@@ -1622,6 +1626,16 @@ namespace SAM.Game
             }
         }
 
+        private void ApplyControlThemes()
+        {
+            string theme = !this.IsLightTheme() && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000)
+                ? "DarkMode_Explorer"
+                : "Explorer";
+
+            SetWindowTheme(this._AchievementListView.Handle, theme, null);
+            SetWindowTheme(this._MainTabControl.Handle, theme, null);
+        }
+
         private bool IsLightTheme()
         {
             try
@@ -1670,6 +1684,7 @@ namespace SAM.Game
             this._MainTabControl.BackColor = this.BackColor;
             this._MainTabControl.ForeColor = this.ForeColor;
 
+            this.ApplyControlThemes();
             this.Invalidate();
         }
         protected override void Dispose(bool disposing)

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -1640,9 +1640,17 @@ namespace SAM.Game
                 SetWindowTheme(header, theme, null);
             }
             SetWindowTheme(this._MainTabControl.Handle, theme, null);
+            SetWindowTheme(this._AchievementsTabPage.Handle, theme, null);
+            SetWindowTheme(this._StatisticsTabPage.Handle, theme, null);
             SetWindowTheme(this._MainToolStrip.Handle, theme, null);
             SetWindowTheme(this._AchievementsToolStrip.Handle, theme, null);
             SetWindowTheme(this._StatisticsDataGridView.Handle, theme, null);
+            foreach (Control child in this._StatisticsDataGridView.Controls)
+            {
+                SetWindowTheme(child.Handle, theme, null);
+            }
+            this._StatisticsDataGridView.ControlAdded -= this.OnStatisticsGridControlAdded;
+            this._StatisticsDataGridView.ControlAdded += this.OnStatisticsGridControlAdded;
             SetWindowTheme(this._EnableStatsEditingCheckBox.Handle, theme, null);
 
             if (this._MatchingStringTextBox.Control != null)
@@ -1657,8 +1665,34 @@ namespace SAM.Game
 
             if (this._LanguageComboBox.ComboBox != null)
             {
-                SetWindowTheme(this._LanguageComboBox.ComboBox.Handle, theme, null);
+                if (this._LanguageComboBox.ComboBox.IsHandleCreated)
+                {
+                    SetWindowTheme(this._LanguageComboBox.ComboBox.Handle, theme, null);
+                }
+                else
+                {
+                    this._LanguageComboBox.ComboBox.HandleCreated += this.OnLanguageComboBoxHandleCreated;
+                }
             }
+        }
+
+        private void OnLanguageComboBoxHandleCreated(object? sender, EventArgs e)
+        {
+            if (sender is Control control)
+            {
+                string theme = !this.IsLightTheme() && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000)
+                    ? "DarkMode_Explorer"
+                    : "Explorer";
+                SetWindowTheme(control.Handle, theme, null);
+            }
+        }
+
+        private void OnStatisticsGridControlAdded(object? sender, ControlEventArgs e)
+        {
+            string theme = !this.IsLightTheme() && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000)
+                ? "DarkMode_Explorer"
+                : "Explorer";
+            SetWindowTheme(e.Control.Handle, theme, null);
         }
 
         private bool IsLightTheme()

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -1634,6 +1634,24 @@ namespace SAM.Game
 
             SetWindowTheme(this._AchievementListView.Handle, theme, null);
             SetWindowTheme(this._MainTabControl.Handle, theme, null);
+            SetWindowTheme(this._MainToolStrip.Handle, theme, null);
+            SetWindowTheme(this._AchievementsToolStrip.Handle, theme, null);
+            SetWindowTheme(this._StatisticsDataGridView.Handle, theme, null);
+
+            if (this._MatchingStringTextBox.Control != null)
+            {
+                SetWindowTheme(this._MatchingStringTextBox.Control.Handle, theme, null);
+            }
+
+            if (this._AddTimerTextBox.Control != null)
+            {
+                SetWindowTheme(this._AddTimerTextBox.Control.Handle, theme, null);
+            }
+
+            if (this._LanguageComboBox.Control != null)
+            {
+                SetWindowTheme(this._LanguageComboBox.Control.Handle, theme, null);
+            }
         }
 
         private bool IsLightTheme()


### PR DESCRIPTION
## Summary
- P/Invoke SetWindowTheme from uxtheme.dll
- Apply Explorer or DarkMode_Explorer theme for key controls when handles created and when colors update

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found; tests for libraries still ran and passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a003feff8883309eb70624ed487963