### PR TITLE
Apply theme to picker ToolStripTextBox

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -362,6 +362,10 @@ namespace SAM.Picker
             this._PickerToolStrip.ForeColor = this.ForeColor;
             this._CloseButton.BackColor = this.BackColor;
             this._CloseButton.ForeColor = this.ForeColor;
+            this._AddGameTextBox.BackColor = this.BackColor;
+            this._AddGameTextBox.ForeColor = this.ForeColor;
+            this._SearchGameTextBox.BackColor = this.BackColor;
+            this._SearchGameTextBox.ForeColor = this.ForeColor;
             this._PickerStatusStrip.BackColor = this.BackColor;
             this._PickerStatusStrip.ForeColor = this.ForeColor;
             this._GameListView.BackColor = this.BackColor;


### PR DESCRIPTION
## Summary
- style the picker ToolStripTextBox controls with the current theme colors

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a01c0d9b5483309437817090fce5e7