### PR TITLE
Fix typo in submit achievements timer

### DIFF
--- a/SAM.Game/Manager.Designer.cs
+++ b/SAM.Game/Manager.Designer.cs
@@ -60,7 +60,7 @@
             _EnableStatsEditingCheckBox = new System.Windows.Forms.CheckBox();
             _StatisticsDataGridView = new System.Windows.Forms.DataGridView();
             _TimeNowtimer = new System.Windows.Forms.Timer(components);
-            _SumbitAchievementsTimer = new System.Windows.Forms.Timer(components);
+            _submitAchievementsTimer = new System.Windows.Forms.Timer(components);
             _idleTimer = new System.Windows.Forms.Timer(components);
             _ToolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             _ToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
@@ -454,10 +454,10 @@
             _TimeNowtimer.Interval = 500;
             _TimeNowtimer.Tick += _TimeNowtimer_Tick;
             // 
-            // _SumbitAchievementsTimer
+            // _submitAchievementsTimer
             // 
-            _SumbitAchievementsTimer.Interval = 1000;
-            _SumbitAchievementsTimer.Tick += _SumbitAchievementsTimer_Tick;
+            _submitAchievementsTimer.Interval = 1000;
+            _submitAchievementsTimer.Tick += _submitAchievementsTimer_Tick;
             // 
             // _idleTimer
             // 
@@ -535,7 +535,7 @@
         private System.Windows.Forms.ToolStripTextBox _AddTimerTextBox;
         private System.Windows.Forms.ToolStripButton _AddTimerButton;
         private System.Windows.Forms.ToolStripButton _TimerSwitchButton;
-        private System.Windows.Forms.Timer _SumbitAchievementsTimer;
+        private System.Windows.Forms.Timer _submitAchievementsTimer;
         private System.Windows.Forms.ToolStripLabel _TimerLabel;
         private System.Windows.Forms.Timer _idleTimer;
         private System.Windows.Forms.ToolStripButton _autoMouseMoveButton;

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -1301,7 +1301,7 @@ namespace SAM.Game
         private void _TimerSwitchButton_Click(object sender, EventArgs e)
         {
             // Toggle the timer's Enabled state
-            _SumbitAchievementsTimer.Enabled = !_SumbitAchievementsTimer.Enabled;
+            _submitAchievementsTimer.Enabled = !_submitAchievementsTimer.Enabled;
 
             // Update the button's text to reflect the new state
             UpdateButtonText();
@@ -1338,7 +1338,7 @@ namespace SAM.Game
         private void UpdateButtonText()
         {
             // Change the button's text based on the timer's current state
-            if (_SumbitAchievementsTimer.Enabled)
+            if (_submitAchievementsTimer.Enabled)
             {
                 _TimerSwitchButton.Text = "Disable Timer";
             }
@@ -1377,7 +1377,7 @@ namespace SAM.Game
             }
         }
 
-        private void _SumbitAchievementsTimer_Tick(object sender, EventArgs e)
+        private void _submitAchievementsTimer_Tick(object sender, EventArgs e)
         {
             bool shouldTriggerStore = false; // Flag to determine if we need to trigger the commit button
             int seconds = DateTime.Now.Second;

--- a/SAM.Game/Manager.resx
+++ b/SAM.Game/Manager.resx
@@ -243,7 +243,7 @@
   <metadata name="_TimeNowtimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1302, 17</value>
   </metadata>
-  <metadata name="_SumbitAchievementsTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="_submitAchievementsTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1528, 17</value>
   </metadata>
   <metadata name="_idleTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">


### PR DESCRIPTION
## Summary
- fix submit timer field and handler name in `Manager`
- update designer/resx references and wire Tick event to new handler

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a032e712988330884d62fbd04c259c