### PR TITLE
Make GetGameImageUrl nullable

### DIFF
--- a/SAM.Picker.Tests/GetGameImageUrlTests.cs
+++ b/SAM.Picker.Tests/GetGameImageUrlTests.cs
@@ -1,3 +1,4 @@
+using System;
 using SAM.Picker;
 using Xunit;
 
@@ -9,7 +10,8 @@ public class GetGameImageUrlTests
         uint id = 123;
         string language = "english";
 
-        string result = GameImageUrlResolver.GetGameImageUrl((a, b) => null, id, language);
+        Func<uint, string, string?> getAppData = (a, b) => null;
+        string? result = GameImageUrlResolver.GetGameImageUrl(getAppData, id, language);
         if (result == null)
         {
             result = $"https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/{id}/header.jpg";

--- a/SAM.Picker/GameImageUrlResolver.cs
+++ b/SAM.Picker/GameImageUrlResolver.cs
@@ -6,9 +6,9 @@ namespace SAM.Picker
 {
     internal static class GameImageUrlResolver
     {
-        internal static string GetGameImageUrl(Func<uint, string, string> getAppData, uint id, string language)
+        internal static string? GetGameImageUrl(Func<uint, string, string?> getAppData, uint id, string language)
         {
-            string candidate;
+            string? candidate;
 
             candidate = getAppData(id, $"small_capsule/{language}");
             if (string.IsNullOrEmpty(candidate) == false)


### PR DESCRIPTION
## Summary
- allow GetGameImageUrl to accept nullable app data and return null when no image is found
- update GetGameImageUrl tests to handle nullable results

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a03f3183f483308cb70c34a9f4cfe6