### PR TITLE
Annotate BitmapExtensions with Windows platform

### DIFF
--- a/SAM.Picker/BitmapExtensions.cs
+++ b/SAM.Picker/BitmapExtensions.cs
@@ -3,9 +3,11 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace SAM.Picker
 {
+    [SupportedOSPlatform("windows")]
     internal static class BitmapExtensions
     {
         public static Bitmap ResizeToFit(this Image image, Size target)


### PR DESCRIPTION
## Summary
- mark `BitmapExtensions` as Windows-specific with `SupportedOSPlatform` attribute
- include `System.Runtime.Versioning` namespace

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a0414779ac8330879f43af246c1d1a