### PR TITLE
Annotate LogoResizeTests with Windows support

### DIFF
--- a/SAM.Picker.Tests/LogoResizeTests.cs
+++ b/SAM.Picker.Tests/LogoResizeTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Drawing;
+using System.Runtime.Versioning;
 using SAM.Picker;
 using Xunit;
 
 public class LogoResizeTests
 {
+    [SupportedOSPlatform("windows")]
     [Fact]
     public void OversizedLogoIsResizedToExpectedSize()
     {


### PR DESCRIPTION
## Summary
- add Windows-specific SupportedOSPlatform attribute to logo resize test
- reference System.Runtime.Versioning in test

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a0424d63b08330a44907a90f926251