### PR TITLE
Mark corrupted logo test as Windows-specific

### DIFF
--- a/SAM.Picker.Tests/ImageValidationTests.cs
+++ b/SAM.Picker.Tests/ImageValidationTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Drawing;
 using System.IO;
+using System.Runtime.Versioning;
 using Xunit;
 
 public class ImageValidationTests
 {
+    [SupportedOSPlatform("windows")]
     [Fact]
     public void CorruptedLogoIsRejected()
     {


### PR DESCRIPTION
## Summary
- import System.Runtime.Versioning for ImageValidationTests
- mark CorruptedLogoIsRejected test as requiring Windows

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a043f5d50c83309258c76021dedb7c