### PR TITLE
Use nullable annotations in Manager registry retrieval and child lookup

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -1543,7 +1543,7 @@ namespace SAM.Game
                     else if (bottom) m.Result = (IntPtr)HTBOTTOM;
                     else
                     {
-                        Control child = this.GetChildAtPoint(pt);
+                        Control? child = this.GetChildAtPoint(pt);
                         if (child == null)
                         {
                             m.Result = (IntPtr)HTCAPTION;
@@ -1643,7 +1643,7 @@ namespace SAM.Game
             try
             {
                 using var key = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
-                object value = key?.GetValue("AppsUseLightTheme");
+                object? value = key?.GetValue("AppsUseLightTheme");
                 if (value is int i)
                 {
                     return i != 0;


### PR DESCRIPTION
## Summary
- use nullable Control for `GetChildAtPoint`
- use nullable object when reading `AppsUseLightTheme` from the registry

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a046364b10833084d6193566a02d00