### PR TITLE
Enable nullable context in GamePicker

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -18,7 +18,9 @@
  *
  * 3. This notice may not be removed or altered from any source
  *    distribution.
- */
+*/
+
+#nullable enable
 
 using System;
 using System.Collections.Concurrent;


### PR DESCRIPTION
## Summary
- enable nullable reference types in GamePicker

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a046463f9883309d4368182017d7b4