### PR TITLE
Apply theme recursively to controls

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -1671,35 +1671,7 @@ namespace SAM.Game
                 this.ForeColor = Color.White;
             }
 
-            this._MainTabControl.BackColor = this.BackColor;
-            this._MainTabControl.ForeColor = this.ForeColor;
-            this._MainToolStrip.BackColor = this.BackColor;
-            this._MainToolStrip.ForeColor = this.ForeColor;
-            this._CloseButton.BackColor = this.BackColor;
-            this._CloseButton.ForeColor = this.ForeColor;
-            this._MainStatusStrip.BackColor = this.BackColor;
-            this._MainStatusStrip.ForeColor = this.ForeColor;
-            this._AchievementsToolStrip.BackColor = this.BackColor;
-            this._AchievementsToolStrip.ForeColor = this.ForeColor;
-            this._AchievementListView.BackColor = this.BackColor;
-            this._AchievementListView.ForeColor = this.ForeColor;
-            this._StatisticsDataGridView.BackgroundColor = this.BackColor;
-            this._StatisticsDataGridView.ForeColor = this.ForeColor;
-            this._MainTabControl.BackColor = this.BackColor;
-            this._MainTabControl.ForeColor = this.ForeColor;
-
-            this._StatisticsTabPage.BackColor = this.BackColor;
-            this._StatisticsTabPage.ForeColor = this.ForeColor;
-            this._AchievementsTabPage.BackColor = this.BackColor;
-            this._AchievementsTabPage.ForeColor = this.ForeColor;
-            this._EnableStatsEditingCheckBox.BackColor = this.BackColor;
-            this._EnableStatsEditingCheckBox.ForeColor = this.ForeColor;
-            this._LanguageComboBox.BackColor = this.BackColor;
-            this._LanguageComboBox.ForeColor = this.ForeColor;
-            this._MatchingStringTextBox.BackColor = this.BackColor;
-            this._MatchingStringTextBox.ForeColor = this.ForeColor;
-            this._AddTimerTextBox.BackColor = this.BackColor;
-            this._AddTimerTextBox.ForeColor = this.ForeColor;
+            ThemeHelper.ApplyTheme(this, this.BackColor, this.ForeColor);
 
             Color restrictedBack = light
                 ? ControlPaint.Light(this._AchievementListView.BackColor)
@@ -1708,27 +1680,8 @@ namespace SAM.Game
             {
                 bool restricted = item.Tag is Stats.AchievementInfo info && (info.Permission & 3) != 0;
                 Color itemBack = restricted ? restrictedBack : this._AchievementListView.BackColor;
-                item.BackColor = itemBack;
-                item.ForeColor = this._AchievementListView.ForeColor;
-                foreach (ListViewItem.ListViewSubItem subItem in item.SubItems)
-                {
-                    subItem.BackColor = itemBack;
-                    subItem.ForeColor = this._AchievementListView.ForeColor;
-                }
+                ThemeHelper.ApplyTheme(item, itemBack, this._AchievementListView.ForeColor);
             }
-
-
-            for (int i = 0; i < this._StatisticsDataGridView.ColumnCount; i++)
-            {
-                this._StatisticsDataGridView.Columns[i].DefaultCellStyle.BackColor = this.BackColor;
-                this._StatisticsDataGridView.Columns[i].DefaultCellStyle.ForeColor = this.ForeColor;
-            }
-            //this._StatisticsDataGridView.Columns[0].DefaultCellStyle.BackColor = this.BackColor;
-            //this._StatisticsDataGridView.Columns[0].DefaultCellStyle.ForeColor = this.ForeColor;
-            //this._StatisticsDataGridView.Columns[1].DefaultCellStyle.BackColor = this.BackColor;
-            //this._StatisticsDataGridView.Columns[1].DefaultCellStyle.ForeColor = this.ForeColor;
-            //this._StatisticsDataGridView.Columns[2].DefaultCellStyle.BackColor = this.BackColor;
-            //this._StatisticsDataGridView.Columns[2].DefaultCellStyle.ForeColor = this.ForeColor;
 
             this.Invalidate();
         }

--- a/SAM.Game/ThemeHelper.cs
+++ b/SAM.Game/ThemeHelper.cs
@@ -1,0 +1,84 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SAM.Game
+{
+    internal static class ThemeHelper
+    {
+        private static void TrySetColor(object target, Color back, Color fore)
+        {
+            var type = target.GetType();
+            var backProp = type.GetProperty("BackColor") ?? type.GetProperty("BackgroundColor");
+            if (backProp?.CanWrite == true)
+            {
+                backProp.SetValue(target, back, null);
+            }
+            var foreProp = type.GetProperty("ForeColor");
+            if (foreProp?.CanWrite == true)
+            {
+                foreProp.SetValue(target, fore, null);
+            }
+        }
+
+        internal static void ApplyTheme(object target, Color back, Color fore)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            TrySetColor(target, back, fore);
+
+            switch (target)
+            {
+                case Control control:
+                    foreach (Control child in control.Controls)
+                    {
+                        ApplyTheme(child, back, fore);
+                    }
+
+                    if (control is ToolStrip toolStrip)
+                    {
+                        foreach (ToolStripItem item in toolStrip.Items)
+                        {
+                            ApplyTheme(item, back, fore);
+                        }
+                    }
+                    else if (control is ListView listView)
+                    {
+                        foreach (ListViewItem item in listView.Items)
+                        {
+                            ApplyTheme(item, back, fore);
+                        }
+                    }
+                    else if (control is DataGridView grid)
+                    {
+                        foreach (DataGridViewColumn column in grid.Columns)
+                        {
+                            ApplyTheme(column, back, fore);
+                        }
+                    }
+                    break;
+
+                case ToolStripDropDownItem dropDown:
+                    foreach (ToolStripItem item in dropDown.DropDownItems)
+                    {
+                        ApplyTheme(item, back, fore);
+                    }
+                    break;
+
+                case ListViewItem listViewItem:
+                    foreach (ListViewItem.ListViewSubItem sub in listViewItem.SubItems)
+                    {
+                        ApplyTheme(sub, back, fore);
+                    }
+                    break;
+
+                case DataGridViewColumn column:
+                    column.DefaultCellStyle.BackColor = back;
+                    column.DefaultCellStyle.ForeColor = fore;
+                    break;
+            }
+        }
+    }
+}

--- a/SAM.Game/ThemeHelper.cs
+++ b/SAM.Game/ThemeHelper.cs
@@ -46,9 +46,12 @@ namespace SAM.Game
                     }
                     else if (control is ListView listView)
                     {
-                        foreach (ListViewItem item in listView.Items)
+                        if (!listView.VirtualMode)
                         {
-                            ApplyTheme(item, back, fore);
+                            foreach (ListViewItem item in listView.Items)
+                            {
+                                ApplyTheme(item, back, fore);
+                            }
                         }
                     }
                     else if (control is DataGridView grid)

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -360,18 +360,7 @@ namespace SAM.Picker
                 this.ForeColor = Color.White;
             }
 
-            this._PickerToolStrip.BackColor = this.BackColor;
-            this._PickerToolStrip.ForeColor = this.ForeColor;
-            this._CloseButton.BackColor = this.BackColor;
-            this._CloseButton.ForeColor = this.ForeColor;
-            this._AddGameTextBox.BackColor = this.BackColor;
-            this._AddGameTextBox.ForeColor = this.ForeColor;
-            this._SearchGameTextBox.BackColor = this.BackColor;
-            this._SearchGameTextBox.ForeColor = this.ForeColor;
-            this._PickerStatusStrip.BackColor = this.BackColor;
-            this._PickerStatusStrip.ForeColor = this.ForeColor;
-            this._GameListView.BackColor = this.BackColor;
-            this._GameListView.ForeColor = this.ForeColor;
+            ThemeHelper.ApplyTheme(this, this.BackColor, this.ForeColor);
 
             this.Invalidate();
         }

--- a/SAM.Picker/ThemeHelper.cs
+++ b/SAM.Picker/ThemeHelper.cs
@@ -1,0 +1,84 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SAM.Picker
+{
+    internal static class ThemeHelper
+    {
+        private static void TrySetColor(object target, Color back, Color fore)
+        {
+            var type = target.GetType();
+            var backProp = type.GetProperty("BackColor") ?? type.GetProperty("BackgroundColor");
+            if (backProp?.CanWrite == true)
+            {
+                backProp.SetValue(target, back, null);
+            }
+            var foreProp = type.GetProperty("ForeColor");
+            if (foreProp?.CanWrite == true)
+            {
+                foreProp.SetValue(target, fore, null);
+            }
+        }
+
+        internal static void ApplyTheme(object target, Color back, Color fore)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            TrySetColor(target, back, fore);
+
+            switch (target)
+            {
+                case Control control:
+                    foreach (Control child in control.Controls)
+                    {
+                        ApplyTheme(child, back, fore);
+                    }
+
+                    if (control is ToolStrip toolStrip)
+                    {
+                        foreach (ToolStripItem item in toolStrip.Items)
+                        {
+                            ApplyTheme(item, back, fore);
+                        }
+                    }
+                    else if (control is ListView listView)
+                    {
+                        foreach (ListViewItem item in listView.Items)
+                        {
+                            ApplyTheme(item, back, fore);
+                        }
+                    }
+                    else if (control is DataGridView grid)
+                    {
+                        foreach (DataGridViewColumn column in grid.Columns)
+                        {
+                            ApplyTheme(column, back, fore);
+                        }
+                    }
+                    break;
+
+                case ToolStripDropDownItem dropDown:
+                    foreach (ToolStripItem item in dropDown.DropDownItems)
+                    {
+                        ApplyTheme(item, back, fore);
+                    }
+                    break;
+
+                case ListViewItem listViewItem:
+                    foreach (ListViewItem.ListViewSubItem sub in listViewItem.SubItems)
+                    {
+                        ApplyTheme(sub, back, fore);
+                    }
+                    break;
+
+                case DataGridViewColumn column:
+                    column.DefaultCellStyle.BackColor = back;
+                    column.DefaultCellStyle.ForeColor = fore;
+                    break;
+            }
+        }
+    }
+}

--- a/SAM.Picker/ThemeHelper.cs
+++ b/SAM.Picker/ThemeHelper.cs
@@ -46,9 +46,12 @@ namespace SAM.Picker
                     }
                     else if (control is ListView listView)
                     {
-                        foreach (ListViewItem item in listView.Items)
+                        if (!listView.VirtualMode)
                         {
-                            ApplyTheme(item, back, fore);
+                            foreach (ListViewItem item in listView.Items)
+                            {
+                                ApplyTheme(item, back, fore);
+                            }
                         }
                     }
                     else if (control is DataGridView grid)


### PR DESCRIPTION
## Summary
- introduce `ThemeHelper` that walks control trees and sets BackColor/ForeColor using reflection
- refactor Manager and GamePicker color updates to call the helper so new controls automatically adopt the theme

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a04e6870848330bb28379cedcdd1a4