### PR TITLE
Handle null nodes during XML parsing

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -472,7 +472,11 @@ namespace SAM.Picker
                 var nodes = navigator.Select("/games/game");
                 while (nodes.MoveNext() == true)
                 {
-                    string type = nodes.Current.GetAttribute("type", "");
+                    string type = nodes.Current?.GetAttribute("type", "");
+                    if (nodes.Current == null)
+                    {
+                        continue;
+                    }
                     if (string.IsNullOrEmpty(type) == true)
                     {
                         type = "normal";
@@ -1013,7 +1017,11 @@ namespace SAM.Picker
                 var nodes = navigator.Select("/games/game");
                 while (nodes.MoveNext() == true)
                 {
-                    string idText = nodes.Current.GetAttribute("id", "");
+                    string idText = nodes.Current?.GetAttribute("id", "");
+                    if (nodes.Current == null)
+                    {
+                        continue;
+                    }
                     if (uint.TryParse(idText, out var id) == false)
                     {
                         continue;


### PR DESCRIPTION
## Summary
- guard against null `nodes.Current` when downloading game list
- add same null checks when loading cached owned games

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a07057f8cc8330865bcde0335617af