### PR TITLE
Guard against null search text in GamePicker search

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -595,7 +595,12 @@ namespace SAM.Picker
                 return;
             }
 
-            var text = e.Text;
+            var text = e.Text ?? string.Empty;
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
             int startIndex = e.StartIndex;
 
             Predicate<GameInfo> predicate;


### PR DESCRIPTION
## Summary
- handle null or empty search strings in `OnGameListViewSearchForVirtualItem`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a0736e4dc08330b10bf13124ff6bb6