### PR TITLE
Guard GamePicker logo download from null arguments

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -638,7 +638,12 @@ namespace SAM.Picker
 
         private void DoDownloadLogo(object sender, DoWorkEventArgs e)
         {
-            var info = (GameInfo)e.Argument;
+            var info = e.Argument as GameInfo;
+            if (info == null)
+            {
+                e.Result = null;
+                return;
+            }
 
             List<string> urls = new() { info.ImageUrl };
             var fallbackUrl = _($"https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/{info.Id}/header.jpg");


### PR DESCRIPTION
## Summary
- prevent `DoDownloadLogo` from throwing when argument isn't a `GameInfo`
- only process logo download when `GameInfo` is available

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a07626d5a083309137a0a0932a346d