### PR TITLE
Ensure URIs are non-null before logo download

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -704,9 +704,16 @@ namespace SAM.Picker
                     continue;
                 }
 
+                if (uri == null)
+                {
+                    continue;
+                }
+
+                Uri nonNullUri = uri;
+
                 try
                 {
-                    var (data, contentType) = this.DownloadDataAsync(uri).GetAwaiter().GetResult();
+                    var (data, contentType) = this.DownloadDataAsync(nonNullUri).GetAwaiter().GetResult();
                     if (contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == false)
                     {
                         throw new InvalidDataException("Invalid content type");


### PR DESCRIPTION
## Summary
- Guard against null URIs in logo download loop
- Avoid invoking `DownloadDataAsync` unless a valid URI is confirmed

## Testing
- `dotnet test` *(errors: Microsoft.NET.Sdk.WindowsDesktop targets not found; tests still passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0775321788330a05ead9de9474288