### PR TITLE
Handle null GameInfo entries when downloading logos

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -804,13 +804,18 @@ namespace SAM.Picker
                     return;
                 }
 
-                GameInfo info;
+                GameInfo? info;
                 while (true)
                 {
                     if (this._LogoQueue.TryDequeue(out info) == false)
                     {
                         this._DownloadStatusLabel.Visible = false;
                         return;
+                    }
+
+                    if (info == null)
+                    {
+                        continue;
                     }
 
                     if (info.Item == null)
@@ -831,7 +836,7 @@ namespace SAM.Picker
                 this._DownloadStatusLabel.Text = $"Downloading {1 + this._LogoQueue.Count} game icons...";
                 this._DownloadStatusLabel.Visible = true;
 
-                this._LogoWorker.RunWorkerAsync(info);
+                this._LogoWorker.RunWorkerAsync(info!);
             }
         }
 


### PR DESCRIPTION
## Summary
- declare dequeued GameInfo as nullable in DownloadNextLogo
- skip null entries when dequeuing game logos

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a07b81b32083308fa39c0c20566099