### PR TITLE
Handle null nodes when loading cached games

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -1039,11 +1039,12 @@ namespace SAM.Picker
                 var nodes = navigator.Select("/games/game");
                 while (nodes.MoveNext() == true)
                 {
-                    string idText = nodes.Current?.GetAttribute("id", "");
                     if (nodes.Current == null)
                     {
                         continue;
                     }
+
+                    string idText = nodes.Current.GetAttribute("id", "");
                     if (uint.TryParse(idText, out var id) == false)
                     {
                         continue;


### PR DESCRIPTION
## Summary
- Prevent null dereference in `LoadCachedOwnedGames` by verifying `nodes.Current` before reading attributes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a07cb1f64883308dc77490e74ceda1