### PR TITLE
Inline AppsUseLightTheme retrieval

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -333,8 +333,7 @@ namespace SAM.Picker
             try
             {
                 using var key = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
-                object value = key?.GetValue("AppsUseLightTheme");
-                if (value is int i)
+                if (key?.GetValue("AppsUseLightTheme") is int i)
                 {
                     return i != 0;
                 }


### PR DESCRIPTION
## Summary
- Inline registry value retrieval in `IsLightTheme` to avoid assigning a nullable value

## Testing
- `dotnet test` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop targets)*

------
https://chatgpt.com/codex/tasks/task_e_68a07eb66ae08330b0c2e3b3c7c3a878