### PR TITLE
Enable nullable context in GameImageUrlResolver

### DIFF
--- a/SAM.Picker/GameImageUrlResolver.cs
+++ b/SAM.Picker/GameImageUrlResolver.cs
@@ -2,16 +2,16 @@ using System;
 using System.Diagnostics;
 using System.IO;
 
+#nullable enable
+
 namespace SAM.Picker
 {
     internal static class GameImageUrlResolver
     {
-#pragma warning disable CS8632
         internal static string? GetGameImageUrl(Func<uint, string, string?> getAppData, uint id, string language)
-        
+
         {
             string? candidate;
-#pragma warning restore CS8632
 
             candidate = getAppData(id, $"small_capsule/{language}");
             if (string.IsNullOrEmpty(candidate) == false)


### PR DESCRIPTION
## Summary
- enable nullable annotations for GameImageUrlResolver

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a07f0b1c2483309283819e89d4073e