### PR TITLE
Handle missing type attribute in game list parsing

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -471,7 +471,7 @@ namespace SAM.Picker
                 var nodes = navigator.Select("/games/game");
                 while (nodes.MoveNext() == true)
                 {
-                    string type = nodes.Current?.GetAttribute("type", "");
+                    string type = nodes.Current?.GetAttribute("type", "") ?? string.Empty;
                     if (nodes.Current == null)
                     {
                         continue;


### PR DESCRIPTION
## Summary
- ensure type attribute fallback to empty string to avoid nullable warning

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a07ffaeb14833097eaa3949c4af75c