### PR TITLE
Allow null cacheFile before initialization

### DIFF
--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -651,7 +651,7 @@ namespace SAM.Picker
                 urls.Add(fallbackUrl);
             }
 
-            string cacheFile = null;
+            string? cacheFile = null;
             if (this._UseIconCache == true)
             {
                 cacheFile = Path.Combine(this._IconCacheDirectory, info.Id + ".png");


### PR DESCRIPTION
## Summary
- allow `cacheFile` to be null before it is assigned when retrieving game logos

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a080dac014833091779178ad742fb1