### PR TITLE
Enhance theme coverage for grids, lists, and tabs

### DIFF
--- a/SAM.WinForms/ThemeHelper.cs
+++ b/SAM.WinForms/ThemeHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace SAM.WinForms
@@ -34,29 +35,46 @@ namespace SAM.WinForms
                 }
             });
 
-            // ListView items.
+            // ListView items and columns.
             RegisterHandler(typeof(ListView), (o, back, fore) =>
             {
                 var list = (ListView)o;
-                if (list.VirtualMode)
+
+                foreach (ColumnHeader column in list.Columns)
                 {
-                    return;
+                    ApplyTheme(column, back, fore);
                 }
 
-                foreach (ListViewItem item in list.Items)
+                if (list.VirtualMode == false)
                 {
-                    ApplyTheme(item, back, fore);
+                    foreach (ListViewItem item in list.Items)
+                    {
+                        ApplyTheme(item, back, fore);
+                    }
                 }
+
+                ApplyScrollBarTheme(list, back);
             });
 
-            // DataGridView columns.
+            // DataGridView columns and headers.
             RegisterHandler(typeof(DataGridView), (o, back, fore) =>
             {
                 var grid = (DataGridView)o;
+                grid.BackgroundColor = back;
+                grid.DefaultCellStyle.BackColor = back;
+                grid.DefaultCellStyle.ForeColor = fore;
+                grid.EnableHeadersVisualStyles = false;
+                grid.ColumnHeadersDefaultCellStyle.BackColor = back;
+                grid.ColumnHeadersDefaultCellStyle.ForeColor = fore;
+                grid.RowHeadersDefaultCellStyle.BackColor = back;
+                grid.RowHeadersDefaultCellStyle.ForeColor = fore;
+
                 foreach (DataGridViewColumn column in grid.Columns)
                 {
                     ApplyTheme(column, back, fore);
                 }
+
+                ApplyScrollBarTheme(grid, back);
             });
 
             // Drop-down items.
@@ -85,6 +103,17 @@ namespace SAM.WinForms
                 var column = (DataGridViewColumn)o;
                 column.DefaultCellStyle.BackColor = back;
                 column.DefaultCellStyle.ForeColor = fore;
+                column.HeaderCell.Style.BackColor = back;
+                column.HeaderCell.Style.ForeColor = fore;
+            });
+
+            // Tab control page text.
+            RegisterHandler(typeof(TabControl), (o, back, fore) =>
+            {
+                var tabs = (TabControl)o;
+                tabs.DrawMode = TabDrawMode.OwnerDrawFixed;
+                tabs.DrawItem -= OnTabControlDrawItem;
+                tabs.DrawItem += OnTabControlDrawItem;
             });
         }
 
@@ -132,6 +161,54 @@ namespace SAM.WinForms
                 foreProp.SetValue(target, fore, null);
             }
         }
+
+        private static void ApplyScrollBarTheme(Control control, Color back)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
+            {
+                return;
+            }
+
+            // Determine if background is dark or light to set appropriate theme.
+            bool dark = back.GetBrightness() < 0.5f;
+            if (control.IsHandleCreated == false)
+            {
+                var handle = control.Handle; // force handle creation
+            }
+
+            int useDark = dark ? 1 : 0;
+            _ = DwmSetWindowAttribute(control.Handle, DWMWA_USE_IMMERSIVE_DARK_MODE, ref useDark, sizeof(int));
+            _ = SetWindowTheme(control.Handle, dark ? "DarkMode_Explorer" : "Explorer", null);
+        }
+
+        private static void OnTabControlDrawItem(object? sender, DrawItemEventArgs e)
+        {
+            if (sender is not TabControl tabs)
+            {
+                return;
+            }
+
+            TabPage page = tabs.TabPages[e.Index];
+            using var back = new SolidBrush(tabs.BackColor);
+            using var fore = new SolidBrush(tabs.ForeColor);
+            e.Graphics.FillRectangle(back, e.Bounds);
+            var bounds = e.Bounds;
+            bounds.Inflate(-2, -2);
+            StringFormat format = new()
+            {
+                Alignment = StringAlignment.Center,
+                LineAlignment = StringAlignment.Center,
+            };
+            e.Graphics.DrawString(page.Text, e.Font, fore, bounds, format);
+        }
+
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hWnd, int attr, ref int attrValue, int attrSize);
+
+        [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
+        private static extern int SetWindowTheme(IntPtr hWnd, string? pszSubAppName, string? pszSubIdList);
     }
 }
 

--- a/SAM.WinForms/ThemeHelper.cs
+++ b/SAM.WinForms/ThemeHelper.cs
@@ -66,13 +66,22 @@ namespace SAM.WinForms
                 grid.EnableHeadersVisualStyles = false;
                 grid.ColumnHeadersDefaultCellStyle.BackColor = back;
                 grid.ColumnHeadersDefaultCellStyle.ForeColor = fore;
+                grid.ColumnHeadersDefaultCellStyle.SelectionBackColor = back;
+                grid.ColumnHeadersDefaultCellStyle.SelectionForeColor = fore;
                 grid.RowHeadersDefaultCellStyle.BackColor = back;
                 grid.RowHeadersDefaultCellStyle.ForeColor = fore;
+                grid.RowHeadersDefaultCellStyle.SelectionBackColor = back;
+                grid.RowHeadersDefaultCellStyle.SelectionForeColor = fore;
 
                 foreach (DataGridViewColumn column in grid.Columns)
                 {
                     ApplyTheme(column, back, fore);
                 }
+
+                grid.TopLeftHeaderCell.Style.BackColor = back;
+                grid.TopLeftHeaderCell.Style.ForeColor = fore;
+                grid.TopLeftHeaderCell.Style.SelectionBackColor = back;
+                grid.TopLeftHeaderCell.Style.SelectionForeColor = fore;
 
                 ApplyScrollBarTheme(grid, back);
             });
@@ -105,6 +114,8 @@ namespace SAM.WinForms
                 column.DefaultCellStyle.ForeColor = fore;
                 column.HeaderCell.Style.BackColor = back;
                 column.HeaderCell.Style.ForeColor = fore;
+                column.HeaderCell.Style.SelectionBackColor = back;
+                column.HeaderCell.Style.SelectionForeColor = fore;
             });
 
             // Tab control page text.
@@ -114,6 +125,13 @@ namespace SAM.WinForms
                 tabs.DrawMode = TabDrawMode.OwnerDrawFixed;
                 tabs.DrawItem -= OnTabControlDrawItem;
                 tabs.DrawItem += OnTabControlDrawItem;
+            });
+
+            // Tab pages must opt out of visual styles for custom colors.
+            RegisterHandler(typeof(TabPage), (o, back, fore) =>
+            {
+                var page = (TabPage)o;
+                page.UseVisualStyleBackColor = false;
             });
         }
 
@@ -189,8 +207,8 @@ namespace SAM.WinForms
             }
 
             TabPage page = tabs.TabPages[e.Index];
-            using var back = new SolidBrush(tabs.BackColor);
-            using var fore = new SolidBrush(tabs.ForeColor);
+            using var back = new SolidBrush(page.BackColor);
+            using var fore = new SolidBrush(page.ForeColor);
             e.Graphics.FillRectangle(back, e.Bounds);
             var bounds = e.Bounds;
             bounds.Inflate(-2, -2);


### PR DESCRIPTION
## Summary
- extend ThemeHelper to recolor DataGridView backgrounds, headers, and row numbers
- apply theme colors to ListView column headers and scrollbar chrome
- render TabControl page captions using themed colors

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08163c82c8330a3300d51611d3e4f