### PR TITLE
Handle potential null references in ThemeHelper

### DIFF
--- a/SAM.WinForms/ThemeHelper.cs
+++ b/SAM.WinForms/ThemeHelper.cs
@@ -224,7 +224,9 @@ namespace SAM.WinForms
                 Alignment = StringAlignment.Near,
                 LineAlignment = StringAlignment.Center,
             };
-            e.Graphics.DrawString(e.Header.Text, list.Font, fore, bounds, format);
+            var text = e.Header?.Text ?? string.Empty;
+            var font = list.Font ?? SystemFonts.DefaultFont;
+            e.Graphics.DrawString(text, font, fore, bounds, format);
         }
 
         private static void OnListViewDrawItem(object? sender, DrawListViewItemEventArgs e)
@@ -255,7 +257,8 @@ namespace SAM.WinForms
                 Alignment = StringAlignment.Center,
                 LineAlignment = StringAlignment.Center,
             };
-            e.Graphics.DrawString(page.Text, e.Font, fore, bounds, format);
+            var font = e.Font ?? SystemFonts.DefaultFont;
+            e.Graphics.DrawString(page.Text ?? string.Empty, font, fore, bounds, format);
         }
 
         private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;


### PR DESCRIPTION
## Summary
- Guard against null `Header` and fallback to default font when drawing ListView headers
- Use a default font and empty text fallback when drawing TabControl items

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68a08bbf502c8330b23b3a6fff5c653d