### PR TITLE
Add ModernPicker project

### DIFF
--- a/SAM.ModernPicker/LICENSE.txt
+++ b/SAM.ModernPicker/LICENSE.txt
@@ -1,0 +1,22 @@
+zlib License
+
+Copyright (c) 2024 Rick (rick 'at' gibbed 'dot' us)
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would
+   be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not
+   be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+   distribution.

--- a/SAM.ModernPicker/ModernPickerForm.Designer.cs
+++ b/SAM.ModernPicker/ModernPickerForm.Designer.cs
@@ -1,0 +1,69 @@
+namespace SAM.ModernPicker
+{
+    partial class ModernPickerForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.TextBox appIdTextBox;
+        private System.Windows.Forms.Button launchButton;
+        private System.Windows.Forms.Label label1;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.appIdTextBox = new System.Windows.Forms.TextBox();
+            this.launchButton = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // appIdTextBox
+            // 
+            this.appIdTextBox.Location = new System.Drawing.Point(64, 12);
+            this.appIdTextBox.Name = "appIdTextBox";
+            this.appIdTextBox.Size = new System.Drawing.Size(150, 23);
+            this.appIdTextBox.TabIndex = 1;
+            // 
+            // launchButton
+            // 
+            this.launchButton.Location = new System.Drawing.Point(220, 11);
+            this.launchButton.Name = "launchButton";
+            this.launchButton.Size = new System.Drawing.Size(75, 25);
+            this.launchButton.TabIndex = 2;
+            this.launchButton.Text = "Launch";
+            this.launchButton.UseVisualStyleBackColor = true;
+            this.launchButton.Click += new System.EventHandler(this.LaunchButton_Click);
+            //
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 15);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(46, 15);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "App ID:";
+            // 
+            // ModernPickerForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(307, 48);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.launchButton);
+            this.Controls.Add(this.appIdTextBox);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ModernPickerForm";
+            this.Text = "SAM Modern Picker";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+    }
+}

--- a/SAM.ModernPicker/ModernPickerForm.cs
+++ b/SAM.ModernPicker/ModernPickerForm.cs
@@ -1,0 +1,50 @@
+/* Copyright (c) 2024 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+using System;
+using System.Windows.Forms;
+
+namespace SAM.ModernPicker
+{
+    public partial class ModernPickerForm : Form
+    {
+        public ModernPickerForm()
+        {
+            InitializeComponent();
+        }
+
+        private void LaunchButton_Click(object sender, EventArgs e)
+        {
+            if (long.TryParse(this.appIdTextBox.Text, out long appId) == false)
+            {
+                MessageBox.Show(
+                    "Invalid App ID.",
+                    "Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return;
+            }
+
+            Program.LaunchGame(appId);
+        }
+    }
+}

--- a/SAM.ModernPicker/ModernPickerForm.resx
+++ b/SAM.ModernPicker/ModernPickerForm.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SAM.ModernPicker/Program.cs
+++ b/SAM.ModernPicker/Program.cs
@@ -1,0 +1,58 @@
+/* Copyright (c) 2024 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+
+namespace SAM.ModernPicker
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            ApplicationConfiguration.Initialize();
+            Application.Run(new ModernPickerForm());
+        }
+
+        public static void LaunchGame(long appId)
+        {
+            string gameExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SAM.Game.exe");
+            if (File.Exists(gameExe) == false)
+            {
+                MessageBox.Show(
+                    "SAM.Game.exe is missing.",
+                    "Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return;
+            }
+
+            Process.Start(new ProcessStartInfo(gameExe, appId.ToString())
+            {
+                UseShellExecute = true,
+            });
+        }
+    }
+}

--- a/SAM.ModernPicker/SAM.ModernPicker.csproj
+++ b/SAM.ModernPicker/SAM.ModernPicker.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyTitle>Steam Achievement Manager Modern Picker</AssemblyTitle>
+    <Company>Gibbed</Company>
+    <Authors>Gibbed</Authors>
+    <Description>A modern game picker for the Steam Achievement Manager.</Description>
+    <Copyright>Copyright © Gibbed 2019</Copyright>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Platforms>x64</Platforms>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <OutputPath>..\\bin\\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <OutputPath>..\\upload\\</OutputPath>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Update="ModernPickerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="ModernPickerForm.Designer.cs">
+      <DependentUpon>ModernPickerForm.cs</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="ModernPickerForm.resx">
+      <DependentUpon>ModernPickerForm.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\SAM.Game\\SAM.Game.csproj" />
+  </ItemGroup>
+</Project>

--- a/SAM.sln
+++ b/SAM.sln
@@ -10,6 +10,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.Game", "SAM.Game\SAM.Ga
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.WinForms", "SAM.WinForms\SAM.WinForms.csproj", "{2602ED96-BF84-4224-94FA-11F93BB45FA1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.ModernPicker", "SAM.ModernPicker\SAM.ModernPicker.csproj", "{0F07CEDA-9CE8-48C5-8DDE-39CF2143B54C}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAM.Picker.Tests", "SAM.Picker.Tests\SAM.Picker.Tests.csproj", "{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAM.Game.Tests", "SAM.Game.Tests\SAM.Game.Tests.csproj", "{4169025E-B068-4FBE-9D60-863C1C5CF0FA}"
@@ -36,6 +38,10 @@ Global
 		{2602ED96-BF84-4224-94FA-11F93BB45FA1}.Debug|x64.Build.0 = Debug|x64
 		{2602ED96-BF84-4224-94FA-11F93BB45FA1}.Release|x64.ActiveCfg = Release|x64
 		{2602ED96-BF84-4224-94FA-11F93BB45FA1}.Release|x64.Build.0 = Release|x64
+                {0F07CEDA-9CE8-48C5-8DDE-39CF2143B54C}.Debug|x64.ActiveCfg = Debug|x64
+                {0F07CEDA-9CE8-48C5-8DDE-39CF2143B54C}.Debug|x64.Build.0 = Debug|x64
+                {0F07CEDA-9CE8-48C5-8DDE-39CF2143B54C}.Release|x64.ActiveCfg = Release|x64
+                {0F07CEDA-9CE8-48C5-8DDE-39CF2143B54C}.Release|x64.Build.0 = Release|x64
 		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Debug|x64.ActiveCfg = Debug|x64
 		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Debug|x64.Build.0 = Debug|x64
 		{22A4F2EE-033C-4B90-8DAF-1F508E38E44C}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
## Summary
- add new SAM.ModernPicker WinForms project
- include icon resources and reference SAM.Game for launching games
- register project in solution
- remove icon assets and related UI settings per review feedback

## Testing
- `dotnet test`
- `dotnet build SAM.ModernPicker/SAM.ModernPicker.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a09576c8a08330a0111f8064367666