### PR TITLE
Add ModernSAM WinUI 3 project

### DIFF
--- a/ModernSAM/ModernSAM.UI/App.xaml
+++ b/ModernSAM/ModernSAM.UI/App.xaml
@@ -1,0 +1,6 @@
+<Application
+    x:Class="ModernSAM.UI.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:ModernSAM.UI">
+</Application>

--- a/ModernSAM/ModernSAM.UI/App.xaml.cs
+++ b/ModernSAM/ModernSAM.UI/App.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml;
+
+namespace ModernSAM.UI;
+
+public partial class App : Application
+{
+    private Window? m_window;
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        m_window = new MainWindow();
+        m_window.Activate();
+    }
+}

--- a/ModernSAM/ModernSAM.UI/MainWindow.xaml
+++ b/ModernSAM/ModernSAM.UI/MainWindow.xaml
@@ -1,0 +1,9 @@
+<Window
+    x:Class="ModernSAM.UI.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="ModernSAM">
+    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <TextBlock Text="ModernSAM" />
+    </StackPanel>
+</Window>

--- a/ModernSAM/ModernSAM.UI/MainWindow.xaml.cs
+++ b/ModernSAM/ModernSAM.UI/MainWindow.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml;
+
+namespace ModernSAM.UI;
+
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/ModernSAM/ModernSAM.UI/ModernSAM.UI.csproj
+++ b/ModernSAM/ModernSAM.UI/ModernSAM.UI.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <UseWinUI>true</UseWinUI>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <AssemblyName>ModernSAM</AssemblyName>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="App.xaml" />
+    <Page Include="MainWindow.xaml" />
+    <Compile Update="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/ModernSAM/ModernSAM.UI/ModernSAM.UI.csproj
+++ b/ModernSAM/ModernSAM.UI/ModernSAM.UI.csproj
@@ -9,7 +9,8 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>ModernSAM</AssemblyName>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ModernSAM/ModernSAM.UI/ModernSAM.UI.csproj
+++ b/ModernSAM/ModernSAM.UI/ModernSAM.UI.csproj
@@ -14,13 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.7" />
   </ItemGroup>
 
   <ItemGroup>
     <Page Include="App.xaml" />
     <Page Include="MainWindow.xaml" />
+    <Compile Include="Program.cs" />
     <Compile Update="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>

--- a/ModernSAM/ModernSAM.UI/Program.cs
+++ b/ModernSAM/ModernSAM.UI/Program.cs
@@ -1,5 +1,5 @@
 using Microsoft.UI.Xaml;
-using Microsoft.Windows.AppLifecycle;
+using Microsoft.Windows.AppSDK;
 using System;
 using System.Runtime.InteropServices;
 

--- a/ModernSAM/ModernSAM.UI/Program.cs
+++ b/ModernSAM/ModernSAM.UI/Program.cs
@@ -1,5 +1,5 @@
 using Microsoft.UI.Xaml;
-using Microsoft.Windows.AppRuntime;
+using Microsoft.Windows.AppLifecycle;
 using System;
 using System.Runtime.InteropServices;
 

--- a/ModernSAM/ModernSAM.UI/Program.cs
+++ b/ModernSAM/ModernSAM.UI/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.UI.Xaml;
+
+namespace ModernSAM.UI;
+
+public static class Program
+{
+    [STAThread]
+    static void Main(string[] args)
+    {
+        Application.Start(p => new App());
+    }
+}

--- a/ModernSAM/ModernSAM.UI/Program.cs
+++ b/ModernSAM/ModernSAM.UI/Program.cs
@@ -1,4 +1,7 @@
 using Microsoft.UI.Xaml;
+using Microsoft.Windows.AppRuntime;
+using System;
+using System.Runtime.InteropServices;
 
 namespace ModernSAM.UI;
 
@@ -7,6 +10,19 @@ public static class Program
     [STAThread]
     static void Main(string[] args)
     {
-        Application.Start(p => new App());
+        try
+        {
+            Bootstrap.Initialize();
+            Application.Start(p => new App());
+        }
+        catch (Exception ex) when (ex is DllNotFoundException || ex is COMException)
+        {
+            Console.Error.WriteLine("ModernSAM.UI requires the Windows App SDK runtime and can only run on Windows.");
+        }
+        finally
+        {
+            // Ensure the Windows App SDK is cleaned up if initialization succeeded
+            Bootstrap.Shutdown();
+        }
     }
 }

--- a/ModernSAM/ModernSAM.sln
+++ b/ModernSAM/ModernSAM.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModernSAM.UI", "ModernSAM.UI\ModernSAM.UI.csproj", "{BED2ACB5-F362-4958-93DA-5246DA67C4A7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BED2ACB5-F362-4958-93DA-5246DA67C4A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BED2ACB5-F362-4958-93DA-5246DA67C4A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BED2ACB5-F362-4958-93DA-5246DA67C4A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BED2ACB5-F362-4958-93DA-5246DA67C4A7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- start ModernSAM solution with a WinUI 3 .NET 8 app
- basic App and MainWindow wired up for a `ModernSAM.exe` entry point

## Testing
- `dotnet build ModernSAM.sln` *(fails: NETSDK1083 RuntimeIdentifier 'win10-x64' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a14c2f72708330bf9259a81b3a4310