### PR TITLE
Add debug logs for icon download caching

### DIFF
--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -271,11 +271,15 @@ namespace SAM.Game
                 id.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
                 id.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
             {
+                var originalId = id;
                 id = Uri.EscapeDataString(id);
+                Debug.WriteLine($"Renaming icon id '{originalId}' to '{id}' for cache file name.");
             }
 
             var fileName = id + "_" + (info.IsAchieved == true ? "achieved" : "locked") + ".png";
-            return Path.Combine(this._IconCacheDirectory, fileName);
+            var path = Path.Combine(this._IconCacheDirectory, fileName);
+            Debug.WriteLine($"Cache path for icon '{info.Id}' resolved to '{path}'.");
+            return path;
         }
 
         private void AddAchievementIcon(Stats.AchievementInfo info, Image? icon)
@@ -342,6 +346,8 @@ namespace SAM.Game
                 Path = $"/steamcommunity/public/images/apps/{this._GameId}/{Uri.EscapeDataString(fileName)}"
             };
 
+            Debug.WriteLine($"Downloading icon from '{builder.Uri}'.");
+
             using var request = new HttpRequestMessage(HttpMethod.Get, builder.Uri);
             using var response = await this._HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
@@ -382,6 +388,7 @@ namespace SAM.Game
                     {
                         try
                         {
+                            Debug.WriteLine($"Caching icon '{info.Id}' to '{cachePath}'.");
                             File.WriteAllBytes(cachePath, data);
                         }
                         catch (Exception)
@@ -879,6 +886,7 @@ namespace SAM.Game
                 {
                     try
                     {
+                        Debug.WriteLine($"Checking cache for icon '{info.Id}' at '{cachePath}'.");
                         if (File.Exists(cachePath) == true)
                         {
                             var bytes = File.ReadAllBytes(cachePath);
@@ -894,6 +902,7 @@ namespace SAM.Game
                                     if (image.Width <= MaxIconDimension && image.Height <= MaxIconDimension)
                                     {
                                         this.AddAchievementIcon(info, image);
+                                        Debug.WriteLine($"Loaded icon '{info.Id}' from cache.");
                                         return;
                                     }
                                 }


### PR DESCRIPTION
## Summary
- log icon URI, cache path resolution, and local caching
- report cache checks when reusing downloaded icons

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5438d31908330a0b5b3bf4a279b8c